### PR TITLE
Automatically create a monitoring topic if one has not already been created.

### DIFF
--- a/config/kafka-monitor.properties
+++ b/config/kafka-monitor.properties
@@ -39,7 +39,7 @@
     "zookeeper.connect": "localhost:2181",
     "bootstrap.servers": "localhost:9092",
     "produce.record.delay.ms": 100,
-    "produce.topic.autoTopicCreationEnabled": false,
+    "produce.topic.autoTopicCreationEnabled": true,
     "produce.topic.autoTopicReplicationFactor" : 1,
     "produce.producer.props": {
       "client.id": "kmf-client-id"

--- a/config/kafka-monitor.properties
+++ b/config/kafka-monitor.properties
@@ -41,7 +41,7 @@
     "produce.record.delay.ms": 100,
     "produce.topic.autoTopicCreationEnabled": true,
     "produce.topic.autoTopicMinIsr" : 2,
-    "produce.topic.autoautoTopicReplicationFactor" : 3,
+    "produce.topic.autoTopicReplicationFactor" : 3,
     "produce.producer.props": {
       "client.id": "kmf-client-id"
     },

--- a/config/kafka-monitor.properties
+++ b/config/kafka-monitor.properties
@@ -40,8 +40,7 @@
     "bootstrap.servers": "localhost:9092",
     "produce.record.delay.ms": 100,
     "produce.topic.autoTopicCreationEnabled": true,
-    "produce.topic.autoTopicMinIsr" : 2,
-    "produce.topic.autoTopicReplicationFactor" : 3,
+    "produce.topic.autoTopicReplicationFactor" : 1,
     "produce.producer.props": {
       "client.id": "kmf-client-id"
     },

--- a/config/kafka-monitor.properties
+++ b/config/kafka-monitor.properties
@@ -39,6 +39,9 @@
     "zookeeper.connect": "localhost:2181",
     "bootstrap.servers": "localhost:9092",
     "produce.record.delay.ms": 100,
+    "produce.topic.autoTopicCreationEnabled": true,
+    "produce.topic.autoTopicMinIsr" : 2,
+    "produce.topic.autoautoTopicReplicationFactor" : 3,
     "produce.producer.props": {
       "client.id": "kmf-client-id"
     },

--- a/config/kafka-monitor.properties
+++ b/config/kafka-monitor.properties
@@ -39,7 +39,7 @@
     "zookeeper.connect": "localhost:2181",
     "bootstrap.servers": "localhost:9092",
     "produce.record.delay.ms": 100,
-    "produce.topic.autoTopicCreationEnabled": true,
+    "produce.topic.autoTopicCreationEnabled": false,
     "produce.topic.autoTopicReplicationFactor" : 1,
     "produce.producer.props": {
       "client.id": "kmf-client-id"

--- a/services/src/main/java/com/linkedin/kmf/common/Utils.java
+++ b/services/src/main/java/com/linkedin/kmf/common/Utils.java
@@ -9,27 +9,14 @@
  */
 package com.linkedin.kmf.common;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
 import java.util.Properties;
-import java.util.Set;
-import kafka.cluster.Broker;
 import kafka.server.KafkaConfig;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.io.Encoder;
 import org.apache.avro.io.JsonEncoder;
-import org.apache.kafka.clients.consumer.ConsumerConfig;
-import org.apache.kafka.clients.consumer.KafkaConsumer;
-import org.apache.kafka.common.Node;
-import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.security.JaasUtils;
-import org.apache.kafka.common.serialization.StringDeserializer;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -109,126 +96,6 @@ public class Utils {
       zkUtils.close();
     }
   }
-
-  /**
-   * This is so you can call KafkaConsumer.partitionsFor don't consume messages from this that is the job of the
-   * ConsumeService.
-   *
-   * @param brokerList probably get this from the configuration file.
-   * @param zkUrl zoo keeper url
-   * @param topic the monitoring topic
-   * @return an initialized KafkaConsumer
-   */
-
-  private static KafkaConsumer<?, ?> constructClientForMetadata(String brokerList, String zkUrl, String topic) {
-
-    Properties consumerProps = new Properties();
-
-    // Assign default config. This has the lowest priority.
-    consumerProps.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
-    consumerProps.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest");
-    consumerProps.put(ConsumerConfig.CLIENT_ID_CONFIG, "kmf-metadata-consumer");
-    consumerProps.put(ConsumerConfig.GROUP_ID_CONFIG, "kmf-metadata-consumer-group");
-    consumerProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
-    consumerProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
-
-    // Assign config specified for ConsumeService.
-    consumerProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList);
-    consumerProps.put("zookeeper.connect", zkUrl);
-
-    KafkaConsumer<String, String> metadataConsumer = new KafkaConsumer<>(consumerProps);
-    metadataConsumer.subscribe(Collections.singletonList(topic));
-    return metadataConsumer;
-  }
-
-  /**
-   *
-   * @param zkUrl the zookeeper url
-   * @param topic the monitored topic
-   * @param partitionThreshold  This assumes that you want to have at least one per broker.  When the number of partitions
-   * @param brokersList this is the list of brokers we would need to create a consumer connection.
-   * @return true if the monitored topic is no longer distributed evenly with respect to the given parameters
-   */
-  public static boolean monitoredTopicNeedsRebalance(String zkUrl, String topic, String brokersList,
-      double partitionThreshold) {
-
-    if (partitionThreshold < 1) {
-      throw new IllegalArgumentException(
-          "partitionThreshold must be greater than or equal to one, but found " + partitionThreshold + ".");
-    }
-
-    ZkUtils zkUtils = ZkUtils.apply(zkUrl, ZK_SESSION_TIMEOUT_MS, ZK_CONNECTION_TIMEOUT_MS, JaasUtils.isZkSecurityEnabled());
-
-    try (KafkaConsumer<?, ?> consumerForMetadata = constructClientForMetadata(brokersList, zkUrl, topic)) {
-      List<PartitionInfo> partitionInfoList = consumerForMetadata.partitionsFor(topic);
-      Collection<Broker> brokers = scala.collection.JavaConversions.asJavaCollection(zkUtils.getAllBrokersInCluster());
-      return monitoredTopicNeedsRebalance(partitionInfoList, brokers, partitionThreshold);
-    } finally {
-      zkUtils.close();
-    }
-  }
-
-  /**
-   * If any of the following conditions are met this returns true:
-   * <ul>
-   *   <li> The minimum number of total monitored partitions falls below floor(brokers * partitionThreshold). </li>
-   *   <li> One or more brokers does not have a monitored partition or falls below the minimum number of monitored partitions. </li>
-   *   <li> One or more brokers is not a leader of a monitored partition. </li>
-   * </ul>
-   * @param partitionInfoList get this from the KafkaConsumer, this should only contain partition info for the monitored topic
-   * @param brokers get this from ZkUtils, this should be all the brokers in the cluster
-   * @param partitionThreshold the lower water mark for when we do not have enough monitored partitions
-   * @return see above
-   */
-  static boolean monitoredTopicNeedsRebalance(List<PartitionInfo> partitionInfoList, Collection<Broker> brokers,
-      double partitionThreshold) {
-
-    int partitionCount = partitionInfoList.size();
-    int minPartitionCount = (int) (partitionCount * partitionThreshold);
-    int minPartitionCountPerBroker = minPartitionCount / brokers.size();
-
-    if (partitionCount > minPartitionCount) {
-      return true;
-    }
-
-    Map<Integer, Integer> brokerToPartitionCount = new HashMap<>(brokers.size());
-    Set<Integer> leaders = new HashSet<>(brokers.size());
-
-    // Count the number of partitions a broker is involved with and if it is a leader for some partition
-    // Check that a partition has at least a certain number of replicas
-    for (PartitionInfo partitionInfo : partitionInfoList) {
-      if (partitionInfo.replicas().length < minPartitionCountPerBroker) {
-        return true;
-      }
-
-      for (Node node : partitionInfo.replicas()) {
-        int broker = node.id();
-        if (!brokerToPartitionCount.containsKey(broker)) {
-          brokerToPartitionCount.put(broker, 0);
-        }
-        int count = brokerToPartitionCount.get(node.id());
-        brokerToPartitionCount.put(broker, count + 1);
-      }
-
-      leaders.add(partitionInfo.replicas()[0].id());
-    }
-
-    // Check that a broker is a leader for at least one partition
-    // Check that a broker has at least minPartitionCountPerBroker
-    for (Broker broker : brokers) {
-      if (!leaders.contains(broker.id())) {
-        return true;
-      }
-      if (!brokerToPartitionCount.containsKey(broker.id())) {
-        return true;
-      }
-      if (brokerToPartitionCount.get(broker.id()) < minPartitionCountPerBroker) {
-        return true;
-      }
-    }
-    return false;
-  }
-
 
   /**
    * @param timestamp time in Ms when this message is generated

--- a/services/src/main/java/com/linkedin/kmf/common/Utils.java
+++ b/services/src/main/java/com/linkedin/kmf/common/Utils.java
@@ -9,14 +9,27 @@
  */
 package com.linkedin.kmf.common;
 
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
+import kafka.cluster.Broker;
 import kafka.server.KafkaConfig;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.io.Encoder;
 import org.apache.avro.io.JsonEncoder;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.security.JaasUtils;
+import org.apache.kafka.common.serialization.StringDeserializer;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -30,8 +43,8 @@ import java.util.Arrays;
 public class Utils {
   private static final Logger LOG = LoggerFactory.getLogger(Utils.class);
 
-  private static final int ZK_CONNECTION_TIMEOUT = 30_000;
-  private static final int ZK_SESSION_TIMEOUT = 30_000;
+  public static final int ZK_CONNECTION_TIMEOUT_MS = 30_000;
+  public static final int ZK_SESSION_TIMEOUT_MS = 30_000;
 
   /**
    * Read number of partitions for the given topic on the specified zookeeper
@@ -41,11 +54,13 @@ public class Utils {
    * @return the number of partitions of the given topic
    */
   public static int getPartitionNumForTopic(String zkUrl, String topic) {
-    ZkUtils zkUtils = ZkUtils.apply(zkUrl, ZK_SESSION_TIMEOUT, ZK_CONNECTION_TIMEOUT, JaasUtils.isZkSecurityEnabled());
-    Seq<String> topics = scala.collection.JavaConversions.asScalaBuffer(Arrays.asList(topic));
-    int partition = zkUtils.getPartitionsForTopics(topics).apply(topic).size();
-    zkUtils.close();
-    return partition;
+    ZkUtils zkUtils = ZkUtils.apply(zkUrl, ZK_SESSION_TIMEOUT_MS, ZK_CONNECTION_TIMEOUT_MS, JaasUtils.isZkSecurityEnabled());
+    try {
+      Seq<String> topics = scala.collection.JavaConversions.asScalaBuffer(Arrays.asList(topic));
+      return zkUtils.getPartitionsForTopics(topics).apply(topic).size();
+    } finally {
+      zkUtils.close();
+    }
   }
 
   /**
@@ -53,16 +68,16 @@ public class Utils {
    * the brokers in the cluster will have partitionFactor partitions.  If the topic exists, but has different parameters
    * then this does nothing to update the parameters.
    *
+   * TODO: Do we care about rack aware mode?  I would think no because we want to spread the topic over all brokers.
    * @param zkUrl zookeeper connection url
    * @param topic topic name
-   * @param minIsr the minimum number of in-sync replicas for the topic
    * @param replicationFactor the replication factor for the topic
    * @param partitionFactor This is multiplied by the number brokers to compute the number of partitions in the topic.
    * @return the number of partitions created
    */
-  public static int createMonitoringTopicIfNotExists(String zkUrl, String topic, int minIsr, int replicationFactor,
+  public static int createMonitoringTopicIfNotExists(String zkUrl, String topic, int replicationFactor,
       int partitionFactor) {
-    ZkUtils zkUtils = ZkUtils.apply(zkUrl, ZK_SESSION_TIMEOUT, ZK_CONNECTION_TIMEOUT, JaasUtils.isZkSecurityEnabled());
+    ZkUtils zkUtils = ZkUtils.apply(zkUrl, ZK_SESSION_TIMEOUT_MS, ZK_CONNECTION_TIMEOUT_MS, JaasUtils.isZkSecurityEnabled());
     try {
       if (AdminUtils.topicExists(zkUtils, topic)) {
         LOG.info("Monitoring topic \"" + topic + "\" already exists.");
@@ -77,6 +92,7 @@ public class Utils {
       }
       int partitionCount = brokerCount * partitionFactor;
 
+      int minIsr = Math.max(replicationFactor - 1, 1);
       Properties topicConfig = new Properties();
       topicConfig.setProperty(KafkaConfig.MinInSyncReplicasProp(), Integer.toString(minIsr));
       AdminUtils.createTopic(zkUtils, topic, partitionCount, replicationFactor, new Properties());
@@ -88,6 +104,125 @@ public class Utils {
     } finally {
       zkUtils.close();
     }
+  }
+
+  /**
+   * This is so you can call KafkaConsumer.partitionsFor don't consume messages from this that is the job of the
+   * ConsumeService.
+   *
+   * @param brokerList probably get this from the configuration file.
+   * @param zkUrl zoo keeper url
+   * @param topic the monitoring topic
+   * @return an initialized KafkaConsumer
+   */
+
+  private static KafkaConsumer<?,?> constructClientForMetadata(String brokerList, String zkUrl, String topic) {
+
+    Properties consumerProps = new Properties();
+
+    // Assign default config. This has the lowest priority.
+    consumerProps.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
+    consumerProps.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest");
+    consumerProps.put(ConsumerConfig.CLIENT_ID_CONFIG, "kmf-metadata-consumer");
+    consumerProps.put(ConsumerConfig.GROUP_ID_CONFIG, "kmf-metadata-consumer-group");
+    consumerProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+    consumerProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+
+    // Assign config specified for ConsumeService.
+    consumerProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList);
+    consumerProps.put("zookeeper.connect", zkUrl);
+
+    KafkaConsumer<String, String> metadataConsumer = new KafkaConsumer<>(consumerProps);
+    metadataConsumer.subscribe(Collections.singletonList(topic));
+    return metadataConsumer;
+  }
+
+  /**
+   *
+   * @param zkUrl the zookeeper url
+   * @param topic the monitored topic
+   * @param partitionThreshold  This assumes that you want to have at least one per broker.  When the number of partitions
+   * @param brokersList this is the list of brokers we would need to create a consumer connection.
+   * @return true if the monitored topic is no longer distributed evenly with respect to the given parameters
+   */
+  public static boolean monitoredTopicNeedsRebalance(String zkUrl, String topic, String brokersList,
+      double partitionThreshold) {
+
+    if (partitionThreshold < 1) {
+      throw new IllegalArgumentException(
+          "partitionThreshold must be greater than or equal to one, but found " + partitionThreshold + ".");
+    }
+
+    ZkUtils zkUtils = ZkUtils.apply(zkUrl, ZK_SESSION_TIMEOUT_MS, ZK_CONNECTION_TIMEOUT_MS, JaasUtils.isZkSecurityEnabled());
+
+    try (KafkaConsumer<?, ?> consumerForMetadata = constructClientForMetadata(brokersList, zkUrl, topic)) {
+      List<PartitionInfo> partitionInfoList = consumerForMetadata.partitionsFor(topic);
+      Collection<Broker> brokers = scala.collection.JavaConversions.asJavaCollection(zkUtils.getAllBrokersInCluster());
+      return monitoredTopicNeedsRebalance(partitionInfoList, brokers, partitionThreshold);
+    } finally {
+      zkUtils.close();
+    }
+  }
+
+  /**
+   * If any of the following conditions are met this returns true:
+   * <ul>
+   *   <li> The minimum number of total monitored partitions falls below floor(brokers * partitionThreshold). </li>
+   *   <li> One or more brokers does not have a monitored partition or falls below the minimum number of monitored partitions. </li>
+   *   <li> One or more brokers is not a leader of a monitored partition. </li>
+   * </ul>
+   * @param partitionInfoList get this from the KafkaConsumer, this should only contain partition info for the monitored topic
+   * @param brokers get this from ZkUtils, this should be all the brokers in the cluster
+   * @param partitionThreshold the lower water mark for when we do not have enough monitored partitions
+   * @return see above
+   */
+  static boolean monitoredTopicNeedsRebalance(List<PartitionInfo> partitionInfoList, Collection<Broker> brokers,
+      double partitionThreshold) {
+
+    int partitionCount = partitionInfoList.size();
+    int minPartitionCount = (int) (partitionCount * partitionThreshold);
+    int minPartitionCountPerBroker = minPartitionCount / brokers.size();
+
+    if (partitionCount > minPartitionCount) {
+      return true;
+    }
+
+    Map<Integer, Integer> brokerToPartitionCount = new HashMap<>(brokers.size());
+    Set<Integer> leaders = new HashSet<>(brokers.size());
+
+    // Count the number of partitions a broker is involved with and if it is a leader for some partition
+    // Check that a partition has at least a certain number of replicas
+    for (PartitionInfo partitionInfo : partitionInfoList) {
+      if (partitionInfo.replicas().length < minPartitionCountPerBroker) {
+        return true;
+      }
+
+      for (Node node : partitionInfo.replicas()) {
+        int broker = node.id();
+        if (!brokerToPartitionCount.containsKey(broker)) {
+          brokerToPartitionCount.put(broker, 0);
+        }
+        int count = brokerToPartitionCount.get(node.id());
+           brokerToPartitionCount.put(broker, count + 1);
+      }
+
+      leaders.add(partitionInfo.replicas()[0].id());
+    }
+
+    // Check that a broker is a leader for at least one partition
+    // Check that a broker has at least minPartitionCountPerBroker
+    for (Broker broker : brokers) {
+      if (!leaders.contains(broker.id())) {
+        return true;
+      }
+      if (!brokerToPartitionCount.containsKey(broker.id())) {
+        return true;
+      }
+      if (brokerToPartitionCount.get(broker.id()) < minPartitionCountPerBroker) {
+        return true;
+      }
+    }
+    return false;
   }
 
 

--- a/services/src/main/java/com/linkedin/kmf/common/Utils.java
+++ b/services/src/main/java/com/linkedin/kmf/common/Utils.java
@@ -40,11 +40,15 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Arrays;
 
+
+/**
+ * Kafka monitoring utilities.
+ */
 public class Utils {
   private static final Logger LOG = LoggerFactory.getLogger(Utils.class);
 
-  public static final int ZK_CONNECTION_TIMEOUT_MS = 30_000;
-  public static final int ZK_SESSION_TIMEOUT_MS = 30_000;
+  private static final int ZK_CONNECTION_TIMEOUT_MS = 30_000;
+  private static final int ZK_SESSION_TIMEOUT_MS = 30_000;
 
   /**
    * Read number of partitions for the given topic on the specified zookeeper
@@ -95,7 +99,7 @@ public class Utils {
       int minIsr = Math.max(replicationFactor - 1, 1);
       Properties topicConfig = new Properties();
       topicConfig.setProperty(KafkaConfig.MinInSyncReplicasProp(), Integer.toString(minIsr));
-      AdminUtils.createTopic(zkUtils, topic, partitionCount, replicationFactor, new Properties());
+      AdminUtils.createTopic(zkUtils, topic, partitionCount, replicationFactor, topicConfig);
 
       LOG.info("Created monitoring topic \"" + topic + "\" with " + partitionCount + " partitions, min ISR of " + minIsr
           + " and replication factor of " + replicationFactor + ".");
@@ -116,7 +120,7 @@ public class Utils {
    * @return an initialized KafkaConsumer
    */
 
-  private static KafkaConsumer<?,?> constructClientForMetadata(String brokerList, String zkUrl, String topic) {
+  private static KafkaConsumer<?, ?> constructClientForMetadata(String brokerList, String zkUrl, String topic) {
 
     Properties consumerProps = new Properties();
 
@@ -203,7 +207,7 @@ public class Utils {
           brokerToPartitionCount.put(broker, 0);
         }
         int count = brokerToPartitionCount.get(node.id());
-           brokerToPartitionCount.put(broker, count + 1);
+        brokerToPartitionCount.put(broker, count + 1);
       }
 
       leaders.add(partitionInfo.replicas()[0].id());

--- a/services/src/main/java/com/linkedin/kmf/services/ProduceService.java
+++ b/services/src/main/java/com/linkedin/kmf/services/ProduceService.java
@@ -145,9 +145,6 @@ public class ProduceService implements Service {
     tags.put("name", _name);
     _sensors = new ProduceMetrics(metrics, tags);
 
-    if (config.getBoolean(ProduceServiceConfig.REBALANCE_ENABLED_CONFIG)) {
-      _executor.scheduleWithFixedDelay(new TopicRebalancer(), 10, 10, TimeUnit.MINUTES);
-    }
   }
 
   @Override
@@ -283,37 +280,6 @@ public class ProduceService implements Service {
         _sensors._produceError.record();
         _sensors._produceErrorPerPartition.get(_partition).record();
         LOG.debug(_name + " failed to send message", e);
-      }
-    }
-  }
-
-  /**
-   * Runs this periodically to rebalance the monitored topic across brokers and to reassign leaders to brokers so that the
-   * monitored topic is sampling all the brokers evenly.
-   */
-  private final class TopicRebalancer implements Runnable {
-
-    @Override
-    public void run() {
-      try {
-
-        if (Utils.monitoredTopicNeedsRebalance(_zkConnect, _topic, _brokerList, _rebalanceThreshold)) {
-          LOG.info("Topic rebalance started.");
-          /* TODO: if number of partitons falls below threshold then create new partitions
-             TODO: if a broker does not have enough partitions then assign it partitions from brokers that have excess
-             TODO: if a broker is not a leader of some partition then make it a leader of some partition by finding out
-             TODO:    which broker is a leader of more than one partiton.  Does this involve moving partitions among brokers?
-             TODO: run a preferred election
-             TODO: if new partitions were created then
-             TODO:    create new produce runnables
-             TODO:    create new metrics
-             TODO:    increment _PartitionNum
-          */
-          LOG.info("Topic rebalance complete.");
-        }
-
-      } catch (Exception e) {
-        LOG.error("Topic rebalance failed with exception.", e);
       }
     }
   }

--- a/services/src/main/java/com/linkedin/kmf/services/ProduceService.java
+++ b/services/src/main/java/com/linkedin/kmf/services/ProduceService.java
@@ -14,6 +14,9 @@ import com.linkedin.kmf.services.configs.ProduceServiceConfig;
 import com.linkedin.kmf.producer.KMBaseProducer;
 import com.linkedin.kmf.producer.BaseProducerRecord;
 import com.linkedin.kmf.producer.NewProducer;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.MetricName;
@@ -39,6 +42,10 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
+
+/**
+ * This sets up the producers used by Kafka Monitoring and some of the reported metrics.
+ */
 public class ProduceService implements Service {
   private static final Logger LOG = LoggerFactory.getLogger(ProduceService.class);
   private static final String METRIC_GROUP_NAME = "produce-service";
@@ -49,19 +56,25 @@ public class ProduceService implements Service {
   private final ScheduledExecutorService _executor;
   private final int _produceDelayMs;
   private final boolean _sync;
-  private final Map<Integer, AtomicLong> _nextIndexPerPartition;
-  private final int _partitionNum;
+  /** This can be updated while running when new partitions are added to the monitored topic. */
+  private final ConcurrentMap<Integer, AtomicLong> _nextIndexPerPartition;
+  /** This is the last thing that should be updated after adding new partitions. */
+  private final AtomicInteger _partitionNum;
   private final int _recordSize;
   private final String _topic;
   private final String _producerId;
   private final AtomicBoolean _running;
+  private final String _zkConnect;
+  private final String _brokerList;
+  private final double _rebalanceThreshold;
 
   public ProduceService(Map<String, Object> props, String name) throws Exception {
     _name = name;
     Map producerPropsOverride = (Map) props.get(ProduceServiceConfig.PRODUCER_PROPS_CONFIG);
     ProduceServiceConfig config = new ProduceServiceConfig(props);
-    String zkConnect = config.getString(ProduceServiceConfig.ZOOKEEPER_CONNECT_CONFIG);
-    String brokerList = config.getString(ProduceServiceConfig.BOOTSTRAP_SERVERS_CONFIG);
+    _zkConnect = config.getString(ProduceServiceConfig.ZOOKEEPER_CONNECT_CONFIG);
+    _brokerList = config.getString(ProduceServiceConfig.BOOTSTRAP_SERVERS_CONFIG);
+    _rebalanceThreshold = config.getDouble(ProduceServiceConfig.REBALANCE_THRESHOLD_CONFIG);
     String producerClass = config.getString(ProduceServiceConfig.PRODUCER_CLASS_CONFIG);
     int threadsNum = config.getInt(ProduceServiceConfig.PRODUCE_THREAD_NUM_CONFIG);
     _topic = config.getString(ProduceServiceConfig.TOPIC_CONFIG);
@@ -69,26 +82,31 @@ public class ProduceService implements Service {
     _produceDelayMs = config.getInt(ProduceServiceConfig.PRODUCE_RECORD_DELAY_MS_CONFIG);
     _recordSize = config.getInt(ProduceServiceConfig.PRODUCE_RECORD_SIZE_BYTE_CONFIG);
     _sync = config.getBoolean(ProduceServiceConfig.PRODUCE_SYNC_CONFIG);
+    _partitionNum = new AtomicInteger(0);
 
-    int existingPartitionCount = Utils.getPartitionNumForTopic(zkConnect, _topic);
+    if (_rebalanceThreshold < 1) {
+      throw new IllegalArgumentException("Rebalance threshold must be greater than one but is set to " + _rebalanceThreshold + ".");
+    }
+
+    int existingPartitionCount = Utils.getPartitionNumForTopic(_zkConnect, _topic);
 
     if (existingPartitionCount <= 0) {
-      if (config.getBoolean(ProduceServiceConfig.CREATE_AUTO_TOPIC_CONFIG)) {
-        int autoTopicMinISR = config.getInt(ProduceServiceConfig.AUTO_TOPIC_MIN_ISR_CONFIG);
+      if (config.getBoolean(ProduceServiceConfig.AUTO_TOPIC_CREATION_ENABLED_CONFIG)) {
         int autoTopicReplicationFactor = config.getInt(ProduceServiceConfig.AUTO_TOPIC_REPLICATION_FACTOR_CONFIG);
         int autoTopicPartitionFactor = config.getInt(ProduceServiceConfig.REBALANCE_PARTITION_MULTIPLE_CONFIG);
-        _partitionNum =
-            Utils.createMonitoringTopicIfNotExists(zkConnect, _topic, autoTopicMinISR, autoTopicReplicationFactor,
-                autoTopicPartitionFactor);
+        _partitionNum.set(
+            Utils.createMonitoringTopicIfNotExists(_zkConnect, _topic, autoTopicReplicationFactor,
+                autoTopicPartitionFactor));
       } else {
          throw new RuntimeException("Can not find valid partition number for topic " + _topic +
              ". Please verify that the topic \"" + _topic + "\" has been created. Ideally the partition number should be"+
              " a multiple of number" +
-             " of brokers in the cluster.  Or else configure " + ProduceServiceConfig.CREATE_AUTO_TOPIC_CONFIG +
+             " of brokers in the cluster.  Or else configure " + ProduceServiceConfig.AUTO_TOPIC_CREATION_ENABLED_CONFIG
+             +
              " to be true.");
       }
     } else {
-      _partitionNum = existingPartitionCount;
+      _partitionNum.set(existingPartitionCount);
     }
 
     Properties producerProps = new Properties();
@@ -108,7 +126,7 @@ public class ProduceService implements Service {
 
     // Assign config specified for ProduceService.
     producerProps.put(ProducerConfig.CLIENT_ID_CONFIG, _producerId);
-    producerProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList);
+    producerProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, _brokerList);
 
     // Assign config specified for producer. This has the highest priority.
     if (producerPropsOverride != null)
@@ -117,7 +135,7 @@ public class ProduceService implements Service {
     _producer = (KMBaseProducer) Class.forName(producerClass).getConstructor(Properties.class).newInstance(producerProps);
 
     _running = new AtomicBoolean(false);
-    _nextIndexPerPartition = new HashMap<>();
+    _nextIndexPerPartition = new ConcurrentHashMap<>();
     _executor = Executors.newScheduledThreadPool(threadsNum);
 
     MetricConfig metricConfig = new MetricConfig().samples(60).timeWindow(1000, TimeUnit.MILLISECONDS);
@@ -127,18 +145,27 @@ public class ProduceService implements Service {
     Map<String, String> tags = new HashMap<>();
     tags.put("name", _name);
     _sensors = new ProduceMetrics(metrics, tags);
+
+    if (config.getBoolean(ProduceServiceConfig.REBALANCE_ENABLED_CONFIG)) {
+      _executor.scheduleWithFixedDelay(new TopicRebalancer(), 10, 10, TimeUnit.MINUTES);
+    }
   }
 
   @Override
   public void start() {
     if (_running.compareAndSet(false, true)) {
-      for (int partition = 0; partition < _partitionNum; partition++) {
-        _nextIndexPerPartition.put(partition, new AtomicLong(0));
-        _executor.scheduleWithFixedDelay(new ProduceRunnable(partition),
-          _produceDelayMs, _produceDelayMs, TimeUnit.MILLISECONDS);
+      int partitionNum = _partitionNum.get();
+      for (int partition = 0; partition < partitionNum; partition++) {
+        scheduleProduceRunnable(partition);
       }
       LOG.info(_name + "/ProduceService started");
     }
+  }
+
+  private void scheduleProduceRunnable(int partition) {
+    _nextIndexPerPartition.put(partition, new AtomicLong(0));
+    _executor.scheduleWithFixedDelay(new ProduceRunnable(partition),
+        _produceDelayMs, _produceDelayMs, TimeUnit.MILLISECONDS);
   }
 
   @Override
@@ -169,24 +196,20 @@ public class ProduceService implements Service {
     public final Metrics metrics;
     private final Sensor _recordsProduced;
     private final Sensor _produceError;
-    private final Map<Integer, Sensor> _recordsProducedPerPartition;
-    private final Map<Integer, Sensor> _produceErrorPerPartition;
+    private final ConcurrentMap<Integer, Sensor> _recordsProducedPerPartition;
+    private final ConcurrentMap<Integer, Sensor> _produceErrorPerPartition;
+    private final Map<String, String> _tags;
 
     public ProduceMetrics(Metrics metrics, final Map<String, String> tags) {
       this.metrics = metrics;
+      this._tags = tags;
 
-      _recordsProducedPerPartition = new HashMap<>();
-      for (int partition = 0; partition < _partitionNum; partition++) {
-        Sensor sensor = metrics.sensor("records-produced-partition-" + partition);
-        sensor.add(new MetricName("records-produced-rate-partition-" + partition, METRIC_GROUP_NAME, "The average number of records per second that are produced to this partition", tags), new Rate());
-        _recordsProducedPerPartition.put(partition, sensor);
-      }
+      _recordsProducedPerPartition = new ConcurrentHashMap<>();
+      _produceErrorPerPartition = new ConcurrentHashMap<>();
 
-      _produceErrorPerPartition = new HashMap<>();
-      for (int partition = 0; partition < _partitionNum; partition++) {
-        Sensor sensor = metrics.sensor("produce-error-partition-" + partition);
-        sensor.add(new MetricName("produce-error-rate-partition-" + partition, METRIC_GROUP_NAME, "The average number of errors per second when producing to this partition", tags), new Rate());
-        _produceErrorPerPartition.put(partition, sensor);
+      int partitionNum = _partitionNum.get();
+      for (int partition = 0; partition < partitionNum; partition++) {
+        addPartitionSensors(partition);
       }
 
       _recordsProduced = metrics.sensor("records-produced");
@@ -202,11 +225,12 @@ public class ProduceService implements Service {
           @Override
           public double measure(MetricConfig config, long now) {
             double availabilitySum = 0.0;
-            for (int partition = 0; partition < _partitionNum; partition++) {
+            int partitionNum = _partitionNum.get();
+            for (int partition = 0; partition < partitionNum; partition++) {
               double recordsProduced = _sensors.metrics.metrics().get(new MetricName("records-produced-rate-partition-" + partition, METRIC_GROUP_NAME, tags)).value();
               double produceError = _sensors.metrics.metrics().get(new MetricName("produce-error-rate-partition-" + partition, METRIC_GROUP_NAME, tags)).value();
               // If there is no error, error rate sensor may expire and the value may be NaN. Treat NaN as 0 for error rate.
-              if (new Double(produceError).isNaN()) {
+              if (Double.isNaN(produceError) || Double.isInfinite(produceError)) {
                 produceError = 0;
               }
               // If there is either succeeded or failed produce to a partition, consider its availability as 0.
@@ -215,10 +239,22 @@ public class ProduceService implements Service {
               }
             }
             // Assign equal weight to per-partition availability when calculating overall availability
-            return availabilitySum / _partitionNum;
+            return availabilitySum / partitionNum;
           }
         }
       );
+    }
+
+    void addPartitionSensors(int partition) {
+      Sensor recordsProducedSensor = metrics.sensor("records-produced-partition-" + partition);
+      recordsProducedSensor.add(new MetricName("records-produced-rate-partition-" + partition, METRIC_GROUP_NAME,
+          "The average number of records per second that are produced to this partition", _tags), new Rate());
+      _recordsProducedPerPartition.put(partition, recordsProducedSensor);
+
+      Sensor errorsSensor = metrics.sensor("produce-error-partition-" + partition);
+      errorsSensor.add(new MetricName("produce-error-rate-partition-" + partition, METRIC_GROUP_NAME,
+          "The average number of errors per second when producing to this partition", _tags), new Rate());
+      _produceErrorPerPartition.put(partition, errorsSensor);
     }
   }
 
@@ -248,6 +284,37 @@ public class ProduceService implements Service {
         _sensors._produceError.record();
         _sensors._produceErrorPerPartition.get(_partition).record();
         LOG.debug(_name + " failed to send message", e);
+      }
+    }
+  }
+
+  /**
+   * Runs this periodically to rebalance the monitored topic across brokers and to reassign leaders to brokers so that the
+   * monitored topic is sampling all the brokers evenly.
+   */
+  private final class TopicRebalancer implements Runnable {
+
+    @Override
+    public void run() {
+      try {
+
+        if (Utils.monitoredTopicNeedsRebalance(_zkConnect, _topic, _brokerList, _rebalanceThreshold)) {
+          LOG.info("Topic rebalance started.");
+          /* TODO: if number of partitons falls below threshold then create new partitions
+             TODO: if a broker does not have enough partitions then assign it partitions from brokers that have excess
+             TODO: if a broker is not a leader of some partition then make it a leader of some partition by finding out
+             TODO:    which broker is a leader of more than one partiton.  Does this involve moving partitions among brokers?
+             TODO: run a preferred election
+             TODO: if new partitions were created then
+             TODO:    create new produce runnables
+             TODO:    create new metrics
+             TODO:    increment _PartitionNum
+          */
+          LOG.info("Topic rebalance complete.");
+        }
+
+      } catch (Exception e) {
+        LOG.error("Topic rebalance failed with exception.", e);
       }
     }
   }

--- a/services/src/main/java/com/linkedin/kmf/services/ProduceService.java
+++ b/services/src/main/java/com/linkedin/kmf/services/ProduceService.java
@@ -69,11 +69,15 @@ public class ProduceService implements Service {
     _produceDelayMs = config.getInt(ProduceServiceConfig.PRODUCE_RECORD_DELAY_MS_CONFIG);
     _recordSize = config.getInt(ProduceServiceConfig.PRODUCE_RECORD_SIZE_BYTE_CONFIG);
     _sync = config.getBoolean(ProduceServiceConfig.PRODUCE_SYNC_CONFIG);
-    _partitionNum = Utils.getPartitionNumForTopic(zkConnect, _topic);
 
-    if (_partitionNum <= 0)
-      throw new RuntimeException("Can not find valid partition number for topic " + _topic +
-        ". Please verify that the topic has been created. Ideally the partition number should be a multiple of number of brokers in the cluster.");
+    int existingPartitionCount = Utils.getPartitionNumForTopic(zkConnect, _topic);
+
+    if (existingPartitionCount <= 0) {
+      _partitionNum = Utils.createMonitoringTopic(zkConnect, _topic, new Properties());
+    } else {
+      _partitionNum = existingPartitionCount;
+    }
+
 
     Properties producerProps = new Properties();
 

--- a/services/src/main/java/com/linkedin/kmf/services/ProduceService.java
+++ b/services/src/main/java/com/linkedin/kmf/services/ProduceService.java
@@ -98,12 +98,11 @@ public class ProduceService implements Service {
             Utils.createMonitoringTopicIfNotExists(_zkConnect, _topic, autoTopicReplicationFactor,
                 autoTopicPartitionFactor));
       } else {
-         throw new RuntimeException("Can not find valid partition number for topic " + _topic +
-             ". Please verify that the topic \"" + _topic + "\" has been created. Ideally the partition number should be"+
-             " a multiple of number" +
-             " of brokers in the cluster.  Or else configure " + ProduceServiceConfig.AUTO_TOPIC_CREATION_ENABLED_CONFIG
-             +
-             " to be true.");
+        throw new RuntimeException("Can not find valid partition number for topic " + _topic +
+            ". Please verify that the topic \"" + _topic + "\" has been created. Ideally the partition number should be" +
+            " a multiple of number" +
+            " of brokers in the cluster.  Or else configure " + ProduceServiceConfig.AUTO_TOPIC_CREATION_ENABLED_CONFIG +
+            " to be true.");
       }
     } else {
       _partitionNum.set(existingPartitionCount);

--- a/services/src/main/java/com/linkedin/kmf/services/configs/ProduceServiceConfig.java
+++ b/services/src/main/java/com/linkedin/kmf/services/configs/ProduceServiceConfig.java
@@ -49,6 +49,29 @@ public class ProduceServiceConfig extends AbstractConfig {
   public static final String PRODUCER_PROPS_CONFIG = "produce.producer.props";
   public static final String PRODUCER_PROPS_DOC = "The properties used to config producer in produce service.";
 
+  public static final String AUTO_TOPIC_MIN_ISR_CONFIG = "produce.topic.autoTopicMinIsr";
+  public static final String AUTO_TOPIC_MIN_ISR_DOC = "When a topic is created automatically this is the min ISR for the topic.";
+
+  public static final String AUTO_TOPIC_REPLICATION_FACTOR_CONFIG = "produce.topic.autoTopicReplicationFactor";
+  public static final String AUTO_TOPIC_REPLICATION_FACTOR_DOC = "When a topic is created automatically this is the "
+      + "replication factor used.";
+
+  public static final String REBALANCE_ENABLED_CONFIG = "produce.topic.rebalanceEnabled";
+  public static final String REBALANCE_ENABLED_DOC = "Periodically move leaders and replica assignments so they are "
+      + "evenly spread amongst brokers.";
+
+  public static final String REBALANCE_PARTITION_MULTIPLE_CONFIG = "produce.topic.rebalancePartitionMultiple";
+  public static final String REBALANCE_PARTITION_MULTIPLE_DOC = "Determines the number of partitions per broker in the ideal case.";
+
+  public static final String REBALANCE_THRESHOLD_CONFIG = "produce.topic.rebalanceThreshold";
+  public static final String REBALANCE_THRESHOLD_DOC = "Determines the number of partitions per broker in the ideal case.";
+
+  public static final String CREATE_AUTO_TOPIC_CONFIG = "produce.topic.autoTopicCreationEnabled";
+  public static final String CREATE_AUTO_TOPIC_DOC = "When true this automatically creates the topic mentioned by \"" +
+      TOPIC_CONFIG + "\" with replication factor \"" + AUTO_TOPIC_REPLICATION_FACTOR_CONFIG + "and min ISR of \"" +
+      AUTO_TOPIC_MIN_ISR_CONFIG + "\" with number of brokers * \"" + REBALANCE_PARTITION_MULTIPLE_CONFIG +
+      "\" partitions.";
+
   static {
     CONFIG = new ConfigDef().define(ZOOKEEPER_CONNECT_CONFIG,
                                     ConfigDef.Type.STRING,
@@ -63,6 +86,11 @@ public class ProduceServiceConfig extends AbstractConfig {
                                     "kafka-monitor-topic",
                                     ConfigDef.Importance.MEDIUM,
                                     TOPIC_DOC)
+                            .define(CREATE_AUTO_TOPIC_CONFIG,
+                                    ConfigDef.Type.BOOLEAN,
+                                    false, //default
+                                    ConfigDef.Importance.MEDIUM,
+                                    CREATE_AUTO_TOPIC_DOC)
                             .define(PRODUCER_CLASS_CONFIG,
                                     ConfigDef.Type.STRING,
                                     NewProducer.class.getCanonicalName(),
@@ -92,7 +120,32 @@ public class ProduceServiceConfig extends AbstractConfig {
                                     ConfigDef.Type.INT,
                                     5,
                                     ConfigDef.Importance.LOW,
-                                    PRODUCE_THREAD_NUM_DOC);
+                                    PRODUCE_THREAD_NUM_DOC)
+                            .define(AUTO_TOPIC_MIN_ISR_CONFIG,
+                                    ConfigDef.Type.INT,
+                                    -1,
+                                    ConfigDef.Importance.LOW,
+                                    AUTO_TOPIC_MIN_ISR_DOC)
+                            .define(AUTO_TOPIC_REPLICATION_FACTOR_CONFIG,
+                                    ConfigDef.Type.INT,
+                                    3,
+                                    ConfigDef.Importance.LOW,
+                                    AUTO_TOPIC_REPLICATION_FACTOR_DOC)
+                            .define(REBALANCE_ENABLED_CONFIG,
+                                    ConfigDef.Type.BOOLEAN,
+                                    false,
+                                    ConfigDef.Importance.LOW,
+                                    REBALANCE_ENABLED_DOC)
+                            .define(REBALANCE_PARTITION_MULTIPLE_CONFIG,
+                                    ConfigDef.Type.INT,
+                                    2,
+                                    ConfigDef.Importance.LOW,
+                                    REBALANCE_PARTITION_MULTIPLE_DOC)
+                            .define(REBALANCE_THRESHOLD_CONFIG,
+                                    ConfigDef.Type.DOUBLE,
+                                    1.5,
+                                    ConfigDef.Importance.LOW,
+                                    REBALANCE_THRESHOLD_DOC);
 
   }
 

--- a/services/src/main/java/com/linkedin/kmf/services/configs/ProduceServiceConfig.java
+++ b/services/src/main/java/com/linkedin/kmf/services/configs/ProduceServiceConfig.java
@@ -85,7 +85,7 @@ public class ProduceServiceConfig extends AbstractConfig {
                                     TOPIC_DOC)
                             .define(AUTO_TOPIC_CREATION_ENABLED_CONFIG,
                                     ConfigDef.Type.BOOLEAN,
-                                    false,
+                                    true,
                                     ConfigDef.Importance.MEDIUM, AUTO_TOPIC_CREATION_ENABLED_DOC)
                             .define(PRODUCER_CLASS_CONFIG,
                                     ConfigDef.Type.STRING,

--- a/services/src/main/java/com/linkedin/kmf/services/configs/ProduceServiceConfig.java
+++ b/services/src/main/java/com/linkedin/kmf/services/configs/ProduceServiceConfig.java
@@ -49,9 +49,6 @@ public class ProduceServiceConfig extends AbstractConfig {
   public static final String PRODUCER_PROPS_CONFIG = "produce.producer.props";
   public static final String PRODUCER_PROPS_DOC = "The properties used to config producer in produce service.";
 
-  public static final String AUTO_TOPIC_MIN_ISR_CONFIG = "produce.topic.autoTopicMinIsr";
-  public static final String AUTO_TOPIC_MIN_ISR_DOC = "When a topic is created automatically this is the min ISR for the topic.";
-
   public static final String AUTO_TOPIC_REPLICATION_FACTOR_CONFIG = "produce.topic.autoTopicReplicationFactor";
   public static final String AUTO_TOPIC_REPLICATION_FACTOR_DOC = "When a topic is created automatically this is the "
       + "replication factor used.";
@@ -66,10 +63,10 @@ public class ProduceServiceConfig extends AbstractConfig {
   public static final String REBALANCE_THRESHOLD_CONFIG = "produce.topic.rebalanceThreshold";
   public static final String REBALANCE_THRESHOLD_DOC = "Determines the number of partitions per broker in the ideal case.";
 
-  public static final String CREATE_AUTO_TOPIC_CONFIG = "produce.topic.autoTopicCreationEnabled";
-  public static final String CREATE_AUTO_TOPIC_DOC = "When true this automatically creates the topic mentioned by \"" +
-      TOPIC_CONFIG + "\" with replication factor \"" + AUTO_TOPIC_REPLICATION_FACTOR_CONFIG + "and min ISR of \"" +
-      AUTO_TOPIC_MIN_ISR_CONFIG + "\" with number of brokers * \"" + REBALANCE_PARTITION_MULTIPLE_CONFIG +
+  public static final String AUTO_TOPIC_CREATION_ENABLED_CONFIG = "produce.topic.autoTopicCreationEnabled";
+  public static final String AUTO_TOPIC_CREATION_ENABLED_DOC = "When true this automatically creates the topic mentioned by \"" +
+      TOPIC_CONFIG + "\" with replication factor \"" + AUTO_TOPIC_REPLICATION_FACTOR_CONFIG + "and min ISR of max(" +
+      AUTO_TOPIC_REPLICATION_FACTOR_CONFIG + "-1, 1) with number of brokers * \"" + REBALANCE_PARTITION_MULTIPLE_CONFIG +
       "\" partitions.";
 
   static {
@@ -86,11 +83,10 @@ public class ProduceServiceConfig extends AbstractConfig {
                                     "kafka-monitor-topic",
                                     ConfigDef.Importance.MEDIUM,
                                     TOPIC_DOC)
-                            .define(CREATE_AUTO_TOPIC_CONFIG,
+                            .define(AUTO_TOPIC_CREATION_ENABLED_CONFIG,
                                     ConfigDef.Type.BOOLEAN,
-                                    false, //default
-                                    ConfigDef.Importance.MEDIUM,
-                                    CREATE_AUTO_TOPIC_DOC)
+                                    false,
+                                    ConfigDef.Importance.MEDIUM, AUTO_TOPIC_CREATION_ENABLED_DOC)
                             .define(PRODUCER_CLASS_CONFIG,
                                     ConfigDef.Type.STRING,
                                     NewProducer.class.getCanonicalName(),
@@ -121,14 +117,9 @@ public class ProduceServiceConfig extends AbstractConfig {
                                     5,
                                     ConfigDef.Importance.LOW,
                                     PRODUCE_THREAD_NUM_DOC)
-                            .define(AUTO_TOPIC_MIN_ISR_CONFIG,
-                                    ConfigDef.Type.INT,
-                                    -1,
-                                    ConfigDef.Importance.LOW,
-                                    AUTO_TOPIC_MIN_ISR_DOC)
                             .define(AUTO_TOPIC_REPLICATION_FACTOR_CONFIG,
                                     ConfigDef.Type.INT,
-                                    3,
+                                    1,
                                     ConfigDef.Importance.LOW,
                                     AUTO_TOPIC_REPLICATION_FACTOR_DOC)
                             .define(REBALANCE_ENABLED_CONFIG,

--- a/tests/src/main/java/com/linkedin/kmf/tests/BasicEndToEndTest.java
+++ b/tests/src/main/java/com/linkedin/kmf/tests/BasicEndToEndTest.java
@@ -85,9 +85,20 @@ public class BasicEndToEndTest implements Test {
   private static ArgumentParser argParser() {
     ArgumentParser parser = ArgumentParsers.newArgumentParser("").defaultHelp(true).description("");
 
-    parser.addArgument("--topic").action(store()).required(false).type(String.class).metavar("TOPIC").dest("topic").help("Produce messages to this topic and consume message from this topic");
+    parser.addArgument("--topic")
+        .action(store())
+        .required(false)
+        .type(String.class)
+        .metavar("TOPIC")
+        .dest("topic")
+        .help("Produce messages to this topic and consume message from this topic");
 
-    parser.addArgument("--producer-id").action(store()).required(false).type(String.class).dest("producerId").help("The producerId will be used by producer client and encoded in the messages to the topic");
+    parser.addArgument("--producer-id")
+        .action(store())
+        .required(false)
+        .type(String.class)
+        .dest("producerId")
+        .help("The producerId will be used by producer client and encoded in the messages to the topic");
 
     parser.addArgument("--broker-list")
         .action(store())

--- a/tests/src/main/java/com/linkedin/kmf/tests/BasicEndToEndTest.java
+++ b/tests/src/main/java/com/linkedin/kmf/tests/BasicEndToEndTest.java
@@ -216,11 +216,8 @@ public class BasicEndToEndTest implements Test {
       props.put(ProduceServiceConfig.PRODUCE_RECORD_SIZE_BYTE_CONFIG, res.getString("recordSize"));
     if (res.getString("producerConfig") != null)
       props.put(ProduceServiceConfig.PRODUCER_PROPS_CONFIG, Utils.loadProps(res.getString("producerConfig")));
-    if (res.getBoolean("autoTopicCreationEnabled") != null) {
+    if (res.getBoolean("autoTopicCreationEnabled") != null)
       props.put(ProduceServiceConfig.AUTO_TOPIC_CREATION_ENABLED_CONFIG, res.getBoolean("autoTopicCreationEnabled"));
-    } else {
-      props.put(ProduceServiceConfig.AUTO_TOPIC_CREATION_ENABLED_CONFIG, true);
-    }
 
     props.put(ProduceServiceConfig.PRODUCE_THREAD_NUM_CONFIG, 5);
 

--- a/tests/src/main/java/com/linkedin/kmf/tests/BasicEndToEndTest.java
+++ b/tests/src/main/java/com/linkedin/kmf/tests/BasicEndToEndTest.java
@@ -216,8 +216,11 @@ public class BasicEndToEndTest implements Test {
       props.put(ProduceServiceConfig.PRODUCE_RECORD_SIZE_BYTE_CONFIG, res.getString("recordSize"));
     if (res.getString("producerConfig") != null)
       props.put(ProduceServiceConfig.PRODUCER_PROPS_CONFIG, Utils.loadProps(res.getString("producerConfig")));
-    if (res.getBoolean("autoTopicCreationEnabled") != null)
+    if (res.getBoolean("autoTopicCreationEnabled") != null) {
       props.put(ProduceServiceConfig.AUTO_TOPIC_CREATION_ENABLED_CONFIG, res.getBoolean("autoTopicCreationEnabled"));
+    } else {
+      props.put(ProduceServiceConfig.AUTO_TOPIC_CREATION_ENABLED_CONFIG, true);
+    }
 
     props.put(ProduceServiceConfig.PRODUCE_THREAD_NUM_CONFIG, 5);
 

--- a/tests/src/main/java/com/linkedin/kmf/tests/BasicEndToEndTest.java
+++ b/tests/src/main/java/com/linkedin/kmf/tests/BasicEndToEndTest.java
@@ -49,7 +49,8 @@ public class BasicEndToEndTest implements Test {
   private final ConsumeService _consumeService;
   private final String _name;
 
-  public BasicEndToEndTest(Map<String, Object> props, String name) throws Exception {
+  public BasicEndToEndTest(Map<String, Object> props, String name)
+      throws Exception {
     _name = name;
     _produceService = new ProduceService(props, name);
     _consumeService = new ConsumeService(props, name);
@@ -82,122 +83,122 @@ public class BasicEndToEndTest implements Test {
 
   /** Get the command-line argument parser. */
   private static ArgumentParser argParser() {
-    ArgumentParser parser = ArgumentParsers
-      .newArgumentParser("")
-      .defaultHelp(true)
-      .description("");
+    ArgumentParser parser = ArgumentParsers.newArgumentParser("").defaultHelp(true).description("");
 
-    parser.addArgument("--topic")
-      .action(store())
-      .required(false)
-      .type(String.class)
-      .metavar("TOPIC")
-      .dest("topic")
-      .help("Produce messages to this topic and consume message from this topic");
+    parser.addArgument("--topic").action(store()).required(false).type(String.class).metavar("TOPIC").dest("topic").help("Produce messages to this topic and consume message from this topic");
 
-    parser.addArgument("--producer-id")
-      .action(store())
-      .required(false)
-      .type(String.class)
-      .dest("producerId")
-      .help("The producerId will be used by producer client and encoded in the messages to the topic");
+    parser.addArgument("--producer-id").action(store()).required(false).type(String.class).dest("producerId").help("The producerId will be used by producer client and encoded in the messages to the topic");
 
     parser.addArgument("--broker-list")
-      .action(store())
-      .required(true)
-      .type(String.class)
-      .metavar("HOST1:PORT1[,HOST2:PORT2[...]]")
-      .dest("brokerList")
-      .help("Comma-separated list of Kafka brokers in the form HOST1:PORT1,HOST2:PORT2,...");
+        .action(store())
+        .required(true)
+        .type(String.class)
+        .metavar("HOST1:PORT1[,HOST2:PORT2[...]]")
+        .dest("brokerList")
+        .help("Comma-separated list of Kafka brokers in the form HOST1:PORT1,HOST2:PORT2,...");
 
     parser.addArgument("--zookeeper")
-      .action(store())
-      .required(true)
-      .type(String.class)
-      .metavar("HOST:PORT")
-      .dest("zkConnect")
-      .help("The connection string for the zookeeper connection in the form host:port");
+        .action(store())
+        .required(true)
+        .type(String.class)
+        .metavar("HOST:PORT")
+        .dest("zkConnect")
+        .help("The connection string for the zookeeper connection in the form host:port");
 
     parser.addArgument("--record-size")
-      .action(store())
-      .required(false)
-      .type(String.class)
-      .metavar("RECORD_SIZE")
-      .dest("recordSize")
-      .help("The size of each record.");
+        .action(store())
+        .required(false)
+        .type(String.class)
+        .metavar("RECORD_SIZE")
+        .dest("recordSize")
+        .help("The size of each record.");
 
     parser.addArgument("--producer-class")
-      .action(store())
-      .required(false)
-      .type(String.class)
-      .metavar("PRODUCER_CLASS_NAME")
-      .dest("producerClassName")
-      .help("Specify the class of producer. Available choices include newProducer or class name");
+        .action(store())
+        .required(false)
+        .type(String.class)
+        .metavar("PRODUCER_CLASS_NAME")
+        .dest("producerClassName")
+        .help("Specify the class of producer. Available choices include newProducer or class name");
 
     parser.addArgument("--consumer-class")
-      .action(store())
-      .required(false)
-      .type(String.class)
-      .metavar("CONSUMER_CLASS_NAME")
-      .dest("consumerClassName")
-      .help("Specify the class of consumer. Available choices include oldConsumer, newConsumer, or class name");
+        .action(store())
+        .required(false)
+        .type(String.class)
+        .metavar("CONSUMER_CLASS_NAME")
+        .dest("consumerClassName")
+        .help("Specify the class of consumer. Available choices include oldConsumer, newConsumer, or class name");
 
     parser.addArgument("--producer.config")
-      .action(store())
-      .required(false)
-      .type(String.class)
-      .metavar("PRODUCER_CONFIG")
-      .dest("producerConfig")
-      .help("Producer config properties file.");
+        .action(store())
+        .required(false)
+        .type(String.class)
+        .metavar("PRODUCER_CONFIG")
+        .dest("producerConfig")
+        .help("Producer config properties file.");
 
     parser.addArgument("--consumer.config")
-      .action(store())
-      .required(false)
-      .type(String.class)
-      .metavar("CONSUMER_CONFIG")
-      .dest("consumerConfig")
-      .help("Consumer config properties file.");
+        .action(store())
+        .required(false)
+        .type(String.class)
+        .metavar("CONSUMER_CONFIG")
+        .dest("consumerConfig")
+        .help("Consumer config properties file.");
 
     parser.addArgument("--report-interval-sec")
-      .action(store())
-      .required(false)
-      .type(String.class)
-      .metavar("REPORT_INTERVAL_SEC")
-      .dest("reportIntervalSec")
-      .help("Interval in sec with which to export stats");
+        .action(store())
+        .required(false)
+        .type(String.class)
+        .metavar("REPORT_INTERVAL_SEC")
+        .dest("reportIntervalSec")
+        .help("Interval in sec with which to export stats");
 
     parser.addArgument("--record-delay-ms")
-      .action(store())
-      .required(false)
-      .type(String.class)
-      .metavar("RECORD_DELAY_MS")
-      .dest("recordDelayMs")
-      .help("The delay in ms before sending next record to the same partition");
+        .action(store())
+        .required(false)
+        .type(String.class)
+        .metavar("RECORD_DELAY_MS")
+        .dest("recordDelayMs")
+        .help("The delay in ms before sending next record to the same partition");
 
     parser.addArgument("--latency-percentile-max-ms")
-      .action(store())
-      .required(false)
-      .type(String.class)
-      .metavar("LATENCY_PERCENTILE_MAX_MS")
-      .dest("latencyPercentileMaxMs")
-      .help("The maximum value in ms expected for latency percentile metric. " +
-            "The percentile will be reported as Double.POSITIVE_INFINITY if its value exceeds the max value.");
+        .action(store())
+        .required(false)
+        .type(String.class)
+        .metavar("LATENCY_PERCENTILE_MAX_MS")
+        .dest("latencyPercentileMaxMs")
+        .help("The maximum value in ms expected for latency percentile metric. "
+            + "The percentile will be reported as Double.POSITIVE_INFINITY if its value exceeds the max value.");
 
     parser.addArgument("--latency-percentile-granularity-ms")
-      .action(store())
-      .required(false)
-      .type(String.class)
-      .metavar("LATENCY_PERCENTILE_GRANULARITY_MS")
-      .dest("latencyPercentileGranularityMs")
-      .help("The granularity in ms of latency percentile metric. This is the width of the bucket used in percentile calculation.");
+        .action(store())
+        .required(false)
+        .type(String.class)
+        .metavar("LATENCY_PERCENTILE_GRANULARITY_MS")
+        .dest("latencyPercentileGranularityMs")
+        .help(
+            "The granularity in ms of latency percentile metric. This is the width of the bucket used in percentile calculation.");
+
+    parser.addArgument("--auto-topic-creation")
+        .action(store())
+        .required(false)
+        .type(Boolean.class)
+        .metavar("AUTO_TOPIC_CREATION_ENABLED")
+        .dest("autoTopicCreationEnabled")
+        .help(ProduceServiceConfig.AUTO_TOPIC_CREATION_ENABLED_DOC);
 
     return parser;
   }
 
-  public static void main(String[] args) throws Exception {
+  public static void main(String[] args)
+      throws Exception {
     ArgumentParser parser = argParser();
-    Namespace res = parser.parseArgs(args);
+    if (args.length == 0) {
+      System.out.println(parser.formatHelp());
+      System.exit(-1);
+    }
 
+    Namespace res = parser.parseArgs(args);
     Map<String, Object> props = new HashMap<>();
 
     // produce service config
@@ -215,6 +216,9 @@ public class BasicEndToEndTest implements Test {
       props.put(ProduceServiceConfig.PRODUCE_RECORD_SIZE_BYTE_CONFIG, res.getString("recordSize"));
     if (res.getString("producerConfig") != null)
       props.put(ProduceServiceConfig.PRODUCER_PROPS_CONFIG, Utils.loadProps(res.getString("producerConfig")));
+    if (res.getBoolean("autoTopicCreationEnabled") != null)
+      props.put(ProduceServiceConfig.AUTO_TOPIC_CREATION_ENABLED_CONFIG, res.getBoolean("autoTopicCreationEnabled"));
+
     props.put(ProduceServiceConfig.PRODUCE_THREAD_NUM_CONFIG, 5);
 
     // consume service config
@@ -226,6 +230,7 @@ public class BasicEndToEndTest implements Test {
       props.put(ConsumeServiceConfig.LATENCY_PERCENTILE_MAX_MS_CONFIG, res.getString("latencyPercentileMaxMs"));
     if (res.getString("latencyPercentileGranularityMs") != null)
       props.put(ConsumeServiceConfig.LATENCY_PERCENTILE_GRANULARITY_MS_CONFIG, res.getString("latencyPercentileGranularityMs"));
+
 
     BasicEndToEndTest test = new BasicEndToEndTest(props, "end-to-end");
     test.start();


### PR DESCRIPTION
This is the first of several changes needed to automatically distribute monitored partitions over the all brokers.  This creates a topic if one has not already been created with twice as many partitions as brokers.

This change has been tested by starting a cluster of three brokers and then verifying that the monitor starts successfully and the log message about the topic starting shows up in the log.

This change should not break any existing processes used to create monitoring topics as the monitor will still use an existing topic for monitoring if it exists.