### PR TITLE
Use testng on the tests project and remove dependencies on junit. 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,10 +27,9 @@ project(':services') {
     compile 'org.eclipse.jetty:jetty-server:8.1.19.v20160209'
     compile 'org.json:json:20140107'
     compile 'com.fasterxml.jackson.core:jackson-databind:2.7.1'
-    compile 'junit:junit:4.6'
     compile 'org.jolokia:jolokia-jvm:1.3.3'
 
-    testCompile 'junit:junit:4.6'
+    testCompile 'org.testng:testng:6.8.8'
   }
 
   tasks.create(name: "copyDependantLibs", type: Copy) {
@@ -52,21 +51,24 @@ project(':services') {
     from sourceSets.test.output
   }
 
-  test {
-    testLogging {
-        events "passed", "skipped", "failed"
-        exceptionFormat = 'full'
-    }
-  }
-
   artifacts {
     archives testJar
   }
 }
 
 project(':tests') {
+
   dependencies {
     compile project(':services')
+  }
+
+  test {
+    useTestNG()
+
+    testLogging {
+      events "passed", "skipped", "failed"
+      exceptionFormat = 'full'
+    }
   }
 }
 
@@ -75,6 +77,7 @@ project(':core') {
     compile project(':tests')
   }
 }
+
 
 task wrapper(type: Wrapper) {
    gradleVersion = '2.11'


### PR DESCRIPTION

    Enable the test configuration on the tests project.
    Remove dependency on junit as it has a conflicting license and kafka monitor does not use it anyway.

 As there are not any unit tests anyway this should not have an negative impact and will allow others to write unit tests.