### PR TITLE
If topic reassignment is in progress then attempt leader election if …

### DIFF
--- a/services/src/main/java/com/linkedin/kmf/services/ConsumeService.java
+++ b/services/src/main/java/com/linkedin/kmf/services/ConsumeService.java
@@ -108,7 +108,7 @@ public class ConsumeService implements Service {
           LOG.error(_name + "/ConsumeService failed", e);
         }
       }
-    }, _name + " consume thread");
+    }, _name + " consume-service");
 
     MetricConfig metricConfig = new MetricConfig().samples(60).timeWindow(1000, TimeUnit.MILLISECONDS);
     List<MetricsReporter> reporters = new ArrayList<>();

--- a/services/src/main/java/com/linkedin/kmf/services/ConsumeService.java
+++ b/services/src/main/java/com/linkedin/kmf/services/ConsumeService.java
@@ -108,7 +108,7 @@ public class ConsumeService implements Service {
           LOG.error(_name + "/ConsumeService failed", e);
         }
       }
-    });
+    }, _name + " consume thread");
 
     MetricConfig metricConfig = new MetricConfig().samples(60).timeWindow(1000, TimeUnit.MILLISECONDS);
     List<MetricsReporter> reporters = new ArrayList<>();

--- a/services/src/main/java/com/linkedin/kmf/services/ProduceService.java
+++ b/services/src/main/java/com/linkedin/kmf/services/ProduceService.java
@@ -158,7 +158,7 @@ public class ProduceService implements Service {
   public void start() {
     if (_running.compareAndSet(false, true)) {
       initializeStateForPartitions();
-      _handleNewPartitionsExecutor.scheduleWithFixedDelay(new HandleNewPartitions(), 40_000, 40_000, TimeUnit.MILLISECONDS);
+      _handleNewPartitionsExecutor.scheduleWithFixedDelay(new NewPartitionHandler(), 40_000, 40_000, TimeUnit.MILLISECONDS);
       LOG.info(_name + "/ProduceService started");
     }
   }
@@ -302,7 +302,7 @@ public class ProduceService implements Service {
    * sensors are added for the new partitions.
    */
 
-  private class HandleNewPartitions implements Runnable {
+  private class NewPartitionHandler implements Runnable {
 
     public void run() {
       int currentPartitionCount = Utils.getPartitionNumForTopic(_zkConnect, _topic);
@@ -335,13 +335,13 @@ public class ProduceService implements Service {
 
     private final AtomicInteger _threadId = new AtomicInteger();
     public Thread newThread(Runnable r) {
-      return new Thread(r, _name + " produce-service-produce " + _threadId.getAndIncrement());
+      return new Thread(r, _name + "-produce-service-produce-" + _threadId.getAndIncrement());
     }
   }
 
   private class HandleNewPartitionsThreadFactory implements ThreadFactory {
     public Thread newThread(Runnable r) {
-      return new Thread(r, _name + " produce-service-handle-new-partitions");
+      return new Thread(r, _name + "-produce-service-new-partition-handler");
     }
   }
 

--- a/services/src/main/java/com/linkedin/kmf/services/ProduceService.java
+++ b/services/src/main/java/com/linkedin/kmf/services/ProduceService.java
@@ -335,13 +335,13 @@ public class ProduceService implements Service {
 
     private final AtomicInteger _threadId = new AtomicInteger();
     public Thread newThread(Runnable r) {
-      return new Thread(r, _name + " produce-service, produce thread " + _threadId.getAndIncrement());
+      return new Thread(r, _name + " produce-service-produce " + _threadId.getAndIncrement());
     }
   }
 
   private class HandleNewPartitionsThreadFactory implements ThreadFactory {
     public Thread newThread(Runnable r) {
-      return new Thread(r, _name + " produce-service, handle-new-partitions thread ");
+      return new Thread(r, _name + " produce-service-handle-new-partitions");
     }
   }
 

--- a/services/src/main/java/com/linkedin/kmf/services/TopicManagementService.java
+++ b/services/src/main/java/com/linkedin/kmf/services/TopicManagementService.java
@@ -192,7 +192,7 @@ public class TopicManagementService implements Service  {
           }
           LOG.info(_serviceName + ": topic rebalance complete.");
         } else {
-          LOG.info(_serviceName + ": topic is in good state, no rebalance needed.");
+          LOG.debug(_serviceName + ": topic is in good state, no rebalance needed.");
         }
       } catch (Exception e) {
         if (e instanceof IOException || e instanceof ZkNodeExistsException) {

--- a/services/src/main/java/com/linkedin/kmf/services/TopicManagementService.java
+++ b/services/src/main/java/com/linkedin/kmf/services/TopicManagementService.java
@@ -33,7 +33,6 @@ import kafka.utils.ZkUtils;
 import org.I0Itec.zkclient.exception.ZkNodeExistsException;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.PartitionInfo;
-import org.apache.kafka.common.errors.InterruptException;
 import org.apache.kafka.common.security.JaasUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/services/src/main/java/com/linkedin/kmf/services/TopicManagementService.java
+++ b/services/src/main/java/com/linkedin/kmf/services/TopicManagementService.java
@@ -216,7 +216,7 @@ public class TopicManagementService implements Service  {
 
   private class TopicManagementServiceThreadFactory implements ThreadFactory {
     public Thread newThread(Runnable r) {
-      return new Thread(r, _serviceName + " topic-management-service thread");
+      return new Thread(r, _serviceName + " topic-management-service");
     }
   }
 

--- a/services/src/main/java/com/linkedin/kmf/services/configs/ProduceServiceConfig.java
+++ b/services/src/main/java/com/linkedin/kmf/services/configs/ProduceServiceConfig.java
@@ -52,7 +52,7 @@ public class ProduceServiceConfig extends AbstractConfig {
   public static final String PRODUCER_PROPS_DOC = "The properties used to config producer in produce service.";
 
   public static final String TOPIC_REPLICATION_FACTOR_CONFIG = "topic-management.replicationFactor";
-  public static final String TOPIC_REPLICATION_FACTOR_DOC = "When a topic is created automatically or rebalanced this is the "
+  public static final String TOPIC_REPLICATION_FACTOR_DOC = "When a topic is created automatically this is the "
       + "replication factor used.";
 
   public static final String TOPIC_CREATION_ENABLED_CONFIG = "produce.topic.topicCreationEnabled";


### PR DESCRIPTION
…needed and do reassignment later.

If we hit the race condition when doing reassignment then catch that ZK exception and try again later.
Assign names to all the threads that ProduceService, ConsumeService and TopicManagementService create,
this way you can distinguish them in dumps, jconsole, jstack and debugger.
