### PR TITLE
Add topic creation to ConsumeService and minor text formatting

### DIFF
--- a/config/kafka-monitor.properties
+++ b/config/kafka-monitor.properties
@@ -39,7 +39,7 @@
     "zookeeper.connect": "localhost:2181",
     "bootstrap.servers": "localhost:9092",
     "produce.record.delay.ms": 100,
-    "produce.topic.topicCreationEnabled": true,
+    "topic-management.topicCreationEnabled": true,
     "topic-management.replicationFactor" : 1,
     "topic-management.partitionsToBrokerRatio" : 2.0,
     "topic-management.partitionsToBrokersRatioThreshold" : 1.5,

--- a/services/src/main/java/com/linkedin/kmf/services/ProduceService.java
+++ b/services/src/main/java/com/linkedin/kmf/services/ProduceService.java
@@ -97,21 +97,20 @@ public class ProduceService implements Service {
       }
     }
 
-    double partitionsToBrokersRatio = config.getDouble(CommonServiceConfig.PARTITIONS_TO_BROKER_RATO_CONFIG);
-    int topicReplicationFactor = config.getInt(ProduceServiceConfig.TOPIC_REPLICATION_FACTOR_CONFIG);
+    double partitionsToBrokersRatio = 1;
+    int topicReplicationFactor = 1;
     int existingPartitionCount = Utils.getPartitionNumForTopic(_zkConnect, _topic);
 
     if (existingPartitionCount <= 0) {
-      if (config.getBoolean(ProduceServiceConfig.TOPIC_CREATION_ENABLED_CONFIG)) {
+      if (config.getBoolean(CommonServiceConfig.TOPIC_CREATION_ENABLED_CONFIG)) {
         _partitionNum.set(
             Utils.createMonitoringTopicIfNotExists(_zkConnect, _topic, topicReplicationFactor,
                 partitionsToBrokersRatio));
       } else {
         throw new RuntimeException("Can not find valid partition number for topic " + _topic +
             ". Please verify that the topic \"" + _topic + "\" has been created. Ideally the partition number should be" +
-            " a multiple of number" +
-            " of brokers in the cluster.  Or else configure " + ProduceServiceConfig.TOPIC_CREATION_ENABLED_CONFIG +
-            " to be true.");
+            " a multiple of number of brokers in the cluster.  Or else configure " +
+            CommonServiceConfig.TOPIC_CREATION_ENABLED_CONFIG + " to be true.");
       }
     } else {
       _partitionNum.set(existingPartitionCount);

--- a/services/src/main/java/com/linkedin/kmf/services/configs/CommonServiceConfig.java
+++ b/services/src/main/java/com/linkedin/kmf/services/configs/CommonServiceConfig.java
@@ -27,4 +27,13 @@ public class CommonServiceConfig {
     + " created or rebalanced.  ceil(nBrokers * partitionsToBrokerRatio) is used to determine the actual number of "
     + "partitions when partitions are added or removed.";
 
+  public static final String TOPIC_REPLICATION_FACTOR_CONFIG = "topic-management.replicationFactor";
+  public static final String TOPIC_REPLICATION_FACTOR_DOC = "When a topic is created automatically this is the "
+      + "replication factor used.";
+
+  public static final String TOPIC_CREATION_ENABLED_CONFIG = "topic-management.topicCreationEnabled";
+  public static final String TOPIC_CREATION_ENABLED_DOC = "When true this automatically creates the topic mentioned by \"" +
+      TOPIC_CONFIG + "\" with replication factor \"" + TOPIC_REPLICATION_FACTOR_CONFIG + "and min ISR of max(" +
+      TOPIC_REPLICATION_FACTOR_CONFIG + "-1, 1) with number of brokers * \"" + PARTITIONS_TO_BROKER_RATO_CONFIG + "\" partitions.";
+
 }

--- a/services/src/main/java/com/linkedin/kmf/services/configs/ProduceServiceConfig.java
+++ b/services/src/main/java/com/linkedin/kmf/services/configs/ProduceServiceConfig.java
@@ -51,16 +51,6 @@ public class ProduceServiceConfig extends AbstractConfig {
   public static final String PRODUCER_PROPS_CONFIG = "produce.producer.props";
   public static final String PRODUCER_PROPS_DOC = "The properties used to config producer in produce service.";
 
-  public static final String TOPIC_REPLICATION_FACTOR_CONFIG = "topic-management.replicationFactor";
-  public static final String TOPIC_REPLICATION_FACTOR_DOC = "When a topic is created automatically this is the "
-      + "replication factor used.";
-
-  public static final String TOPIC_CREATION_ENABLED_CONFIG = "produce.topic.topicCreationEnabled";
-  public static final String TOPIC_CREATION_ENABLED_DOC = "When true this automatically creates the topic mentioned by \"" +
-      TOPIC_CONFIG + "\" with replication factor \"" + TOPIC_REPLICATION_FACTOR_CONFIG
-    + "and min ISR of max(" + TOPIC_REPLICATION_FACTOR_CONFIG + "-1, 1) with number of brokers * \"" +
-    CommonServiceConfig.PARTITIONS_TO_BROKER_RATO_CONFIG + "\" partitions.";
-
   static {
     CONFIG = new ConfigDef().define(ZOOKEEPER_CONNECT_CONFIG,
                                     ConfigDef.Type.STRING,
@@ -75,11 +65,6 @@ public class ProduceServiceConfig extends AbstractConfig {
                                     "kafka-monitor-topic",
                                     ConfigDef.Importance.MEDIUM,
                                     TOPIC_DOC)
-                            .define(TOPIC_CREATION_ENABLED_CONFIG,
-                                    ConfigDef.Type.BOOLEAN,
-                                    true,
-                                    ConfigDef.Importance.MEDIUM,
-                                    TOPIC_CREATION_ENABLED_DOC)
                             .define(PRODUCER_CLASS_CONFIG,
                                     ConfigDef.Type.STRING,
                                     NewProducer.class.getCanonicalName(),
@@ -111,18 +96,11 @@ public class ProduceServiceConfig extends AbstractConfig {
                                     atLeast(1),
                                     ConfigDef.Importance.LOW,
                                     PRODUCE_THREAD_NUM_DOC)
-                            .define(TOPIC_REPLICATION_FACTOR_CONFIG,
-                                    ConfigDef.Type.INT,
-                                    1,
-                                    atLeast(1),
-                                    ConfigDef.Importance.LOW,
-                                    TOPIC_REPLICATION_FACTOR_DOC)
-                            .define(CommonServiceConfig.PARTITIONS_TO_BROKER_RATO_CONFIG,
-                                    ConfigDef.Type.DOUBLE,
-                                    2.0,
-                                    atLeast(1.0),
-                                    ConfigDef.Importance.LOW,
-                                    CommonServiceConfig.PARTITIONS_TO_BROKER_RATIO_DOC);
+                            .define(CommonServiceConfig.TOPIC_CREATION_ENABLED_CONFIG,
+                                ConfigDef.Type.BOOLEAN,
+                                true,
+                                ConfigDef.Importance.LOW,
+                                CommonServiceConfig.TOPIC_CREATION_ENABLED_DOC);
 
   }
 

--- a/services/src/main/java/com/linkedin/kmf/services/configs/TopicManagementServiceConfig.java
+++ b/services/src/main/java/com/linkedin/kmf/services/configs/TopicManagementServiceConfig.java
@@ -58,7 +58,18 @@ public class TopicManagementServiceConfig extends AbstractConfig {
               2.0,
               atLeast(1),
               ConfigDef.Importance.LOW,
-              CommonServiceConfig.PARTITIONS_TO_BROKER_RATIO_DOC);
+              CommonServiceConfig.PARTITIONS_TO_BROKER_RATIO_DOC)
+      .define(CommonServiceConfig.TOPIC_CREATION_ENABLED_CONFIG,
+          ConfigDef.Type.BOOLEAN,
+          true,
+          ConfigDef.Importance.LOW,
+          CommonServiceConfig.TOPIC_CREATION_ENABLED_DOC)
+      .define(CommonServiceConfig.TOPIC_REPLICATION_FACTOR_CONFIG,
+          ConfigDef.Type.INT,
+          1,
+          atLeast(1),
+          ConfigDef.Importance.LOW,
+          CommonServiceConfig.TOPIC_REPLICATION_FACTOR_DOC);
   }
 
   public TopicManagementServiceConfig(Map<?, ?> props) {

--- a/tests/src/main/java/com/linkedin/kmf/tests/BasicEndToEndTest.java
+++ b/tests/src/main/java/com/linkedin/kmf/tests/BasicEndToEndTest.java
@@ -13,6 +13,7 @@ import com.linkedin.kmf.services.TopicManagementService;
 import com.linkedin.kmf.services.configs.ConsumeServiceConfig;
 import com.linkedin.kmf.services.configs.DefaultMetricsReporterServiceConfig;
 import com.linkedin.kmf.services.configs.ProduceServiceConfig;
+import com.linkedin.kmf.services.configs.CommonServiceConfig;
 import com.linkedin.kmf.services.ConsumeService;
 import com.linkedin.kmf.services.JettyService;
 import com.linkedin.kmf.services.JolokiaService;
@@ -54,16 +55,16 @@ public class BasicEndToEndTest implements Test {
 
   public BasicEndToEndTest(Map<String, Object> props, String name) throws Exception {
     _name = name;
+    _topicManagementService = new TopicManagementService(props, name);
     _produceService = new ProduceService(props, name);
     _consumeService = new ConsumeService(props, name);
-    _topicManagementService = new TopicManagementService(props, name);
   }
 
   @Override
   public void start() {
+    _topicManagementService.start();
     _produceService.start();
     _consumeService.start();
-    _topicManagementService.start();
     LOG.info(_name + "/BasicEndToEndTest started");
   }
 
@@ -204,7 +205,7 @@ public class BasicEndToEndTest implements Test {
       .type(Boolean.class)
       .metavar("AUTO_TOPIC_CREATION_ENABLED")
       .dest("autoTopicCreationEnabled")
-      .help(ProduceServiceConfig.TOPIC_CREATION_ENABLED_DOC);
+      .help(CommonServiceConfig.TOPIC_CREATION_ENABLED_DOC);
 
     parser.addArgument("--topic-rebalance-interval-ms")
       .action(store())
@@ -244,7 +245,7 @@ public class BasicEndToEndTest implements Test {
     if (res.getString("producerConfig") != null)
       props.put(ProduceServiceConfig.PRODUCER_PROPS_CONFIG, Utils.loadProps(res.getString("producerConfig")));
     if (res.getBoolean("autoTopicCreationEnabled") != null)
-      props.put(ProduceServiceConfig.TOPIC_CREATION_ENABLED_CONFIG, res.getBoolean("autoTopicCreationEnabled"));
+      props.put(CommonServiceConfig.TOPIC_CREATION_ENABLED_CONFIG, res.getBoolean("autoTopicCreationEnabled"));
     if (res.getInt("rebalanceMs") != null)
       props.put(TopicManagementServiceConfig.REBALANCE_INTERVAL_MS_CONFIG, res.getInt("rebalanceMs"));
 


### PR DESCRIPTION

- Allow for topic creation to work when using separate produce/consume clusters by adding topic creation in the ConsumeService
- Fix minor text formatting in ProduceService