### PR TITLE
Move topic creation from produce service to Topic Management Service.

### DIFF
--- a/config/kafka-monitor.properties
+++ b/config/kafka-monitor.properties
@@ -39,7 +39,7 @@
     "zookeeper.connect": "localhost:2181",
     "bootstrap.servers": "localhost:9092",
     "produce.record.delay.ms": 100,
-    "produce.topic.topicCreationEnabled": true,
+    "topic-management.topicCreationEnabled": true,
     "topic-management.replicationFactor" : 1,
     "topic-management.partitionsToBrokerRatio" : 2.0,
     "topic-management.partitionsToBrokersRatioThreshold" : 1.5,

--- a/src/main/java/com/linkedin/kmf/apps/SingleClusterMonitor.java
+++ b/src/main/java/com/linkedin/kmf/apps/SingleClusterMonitor.java
@@ -204,7 +204,7 @@ public class SingleClusterMonitor implements App {
       .type(Boolean.class)
       .metavar("AUTO_TOPIC_CREATION_ENABLED")
       .dest("autoTopicCreationEnabled")
-      .help(ProduceServiceConfig.TOPIC_CREATION_ENABLED_DOC);
+      .help(TopicManagementServiceConfig.TOPIC_CREATION_ENABLED_DOC);
 
     parser.addArgument("--topic-rebalance-interval-ms")
       .action(store())
@@ -244,7 +244,7 @@ public class SingleClusterMonitor implements App {
     if (res.getString("producerConfig") != null)
       props.put(ProduceServiceConfig.PRODUCER_PROPS_CONFIG, Utils.loadProps(res.getString("producerConfig")));
     if (res.getBoolean("autoTopicCreationEnabled") != null)
-      props.put(ProduceServiceConfig.TOPIC_CREATION_ENABLED_CONFIG, res.getBoolean("autoTopicCreationEnabled"));
+      props.put(TopicManagementServiceConfig.TOPIC_CREATION_ENABLED_CONFIG, res.getBoolean("autoTopicCreationEnabled"));
     if (res.getInt("rebalanceMs") != null)
       props.put(TopicManagementServiceConfig.REBALANCE_INTERVAL_MS_CONFIG, res.getInt("rebalanceMs"));
 
@@ -260,8 +260,8 @@ public class SingleClusterMonitor implements App {
     if (res.getString("latencyPercentileGranularityMs") != null)
       props.put(ConsumeServiceConfig.LATENCY_PERCENTILE_GRANULARITY_MS_CONFIG, res.getString("latencyPercentileGranularityMs"));
 
-    SingleClusterMonitor test = new SingleClusterMonitor(props, "end-to-end");
-    test.start();
+    SingleClusterMonitor app = new SingleClusterMonitor(props, "end-to-end");
+    app.start();
 
     // metrics export service config
     props = new HashMap<>();
@@ -289,6 +289,6 @@ public class SingleClusterMonitor implements App {
     JettyService jettyService = new JettyService(new HashMap<String, Object>(), "end-to-end");
     jettyService.start();
 
-    test.awaitShutdown();
+    app.awaitShutdown();
   }
 }

--- a/src/main/java/com/linkedin/kmf/common/Utils.java
+++ b/src/main/java/com/linkedin/kmf/common/Utils.java
@@ -9,6 +9,7 @@
  */
 package com.linkedin.kmf.common;
 
+import java.util.NoSuchElementException;
 import java.util.Properties;
 import kafka.admin.RackAwareMode;
 import kafka.server.KafkaConfig;
@@ -50,6 +51,8 @@ public class Utils {
     try {
       Seq<String> topics = scala.collection.JavaConversions.asScalaBuffer(Arrays.asList(topic));
       return zkUtils.getPartitionsForTopics(topics).apply(topic).size();
+    } catch (NoSuchElementException e) {
+      return 0;
     } finally {
       zkUtils.close();
     }

--- a/src/main/java/com/linkedin/kmf/services/ProduceService.java
+++ b/src/main/java/com/linkedin/kmf/services/ProduceService.java
@@ -10,15 +10,24 @@
 package com.linkedin.kmf.services;
 
 import com.linkedin.kmf.common.Utils;
-import com.linkedin.kmf.services.configs.ProduceServiceConfig;
-import com.linkedin.kmf.producer.KMBaseProducer;
 import com.linkedin.kmf.producer.BaseProducerRecord;
+import com.linkedin.kmf.producer.KMBaseProducer;
 import com.linkedin.kmf.producer.NewProducer;
+import com.linkedin.kmf.services.configs.ProduceServiceConfig;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
-import com.linkedin.kmf.topicfactory.TopicFactory;
+import java.util.concurrent.atomic.AtomicLong;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.MetricName;
@@ -34,16 +43,6 @@ import org.apache.kafka.common.metrics.stats.Total;
 import org.apache.kafka.common.utils.SystemTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicLong;
 
 
 public class ProduceService implements Service {
@@ -90,8 +89,8 @@ public class ProduceService implements Service {
     _partitionNum = new AtomicInteger(0);
     _running = new AtomicBoolean(false);
     _nextIndexPerPartition = new ConcurrentHashMap<>();
-    _producerPropsOverride = props.containsKey(ProduceServiceConfig.PRODUCER_PROPS_CONFIG) ?
-      (Map) props.get(ProduceServiceConfig.PRODUCER_PROPS_CONFIG) : new HashMap<>();
+    _producerPropsOverride = props.containsKey(ProduceServiceConfig.PRODUCER_PROPS_CONFIG)
+      ? (Map) props.get(ProduceServiceConfig.PRODUCER_PROPS_CONFIG) : new HashMap<>();
 
     for (String property: NONOVERRIDABLE_PROPERTIES) {
       if (_producerPropsOverride.containsKey(property)) {
@@ -297,8 +296,10 @@ public class ProduceService implements Service {
 
     public void run() {
       int currentPartitionCount = Utils.getPartitionNumForTopic(_zkConnect, _topic);
-      if (currentPartitionCount == _partitionNum.get()) {
+      if (currentPartitionCount <= 0) {
         LOG.info(_name + ": Topic named " + _topic + " does not exist.");
+        return;
+      } else if (currentPartitionCount == _partitionNum.get()) {
         return;
       }
       LOG.info(_name + ": Detected new partitions to monitor.");

--- a/src/main/java/com/linkedin/kmf/services/ProduceService.java
+++ b/src/main/java/com/linkedin/kmf/services/ProduceService.java
@@ -100,10 +100,7 @@ public class ProduceService implements Service {
       }
     }
 
-    double partitionsToBrokersRatio = config.getDouble(CommonServiceConfig.PARTITIONS_TO_BROKER_RATO_CONFIG);
-    int topicReplicationFactor = config.getInt(ProduceServiceConfig.TOPIC_REPLICATION_FACTOR_CONFIG);
     int existingPartitionCount = Utils.getPartitionNumForTopic(_zkConnect, _topic);
-
     if (existingPartitionCount <= 0) {
       if (config.getBoolean(ProduceServiceConfig.TOPIC_CREATION_ENABLED_CONFIG)) {
         TopicFactory topicFactory =
@@ -113,9 +110,8 @@ public class ProduceService implements Service {
       } else {
         throw new RuntimeException("Can not find valid partition number for topic " + _topic +
             ". Please verify that the topic \"" + _topic + "\" has been created. Ideally the partition number should be" +
-            " a multiple of number" +
-            " of brokers in the cluster.  Or else configure " + ProduceServiceConfig.TOPIC_CREATION_ENABLED_CONFIG +
-            " to be true.");
+            " a multiple of number of brokers in the cluster.  Or else configure " +
+            CommonServiceConfig.TOPIC_CREATION_ENABLED_CONFIG + " to be true.");
       }
     } else {
       _partitionNum.set(existingPartitionCount);

--- a/src/main/java/com/linkedin/kmf/services/ProduceService.java
+++ b/src/main/java/com/linkedin/kmf/services/ProduceService.java
@@ -99,15 +99,7 @@ public class ProduceService implements Service {
       }
     }
 
-    int existingPartitionCount = Utils.getPartitionNumForTopic(_zkConnect, _topic);
-    int topicPollDelay = config.getInt(ProduceServiceConfig.TOPIC_POLL_DELAY_CONFIG);
-    while (existingPartitionCount <= 0) {
-      LOG.info(_name + ": Topic named " +  _topic + " has not been created. Checking again in " + topicPollDelay + "ms.");
-      Thread.sleep(topicPollDelay);
-      existingPartitionCount = Utils.getPartitionNumForTopic(_zkConnect, _topic);
-    }
-
-    _partitionNum.set(existingPartitionCount);
+    _partitionNum.set(Utils.getPartitionNumForTopic(_zkConnect, _topic));
 
     if (producerClass.equals(NewProducer.class.getCanonicalName()) || producerClass.equals(NewProducer.class.getSimpleName())) {
       _producerClassName = NewProducer.class.getCanonicalName();
@@ -306,6 +298,7 @@ public class ProduceService implements Service {
     public void run() {
       int currentPartitionCount = Utils.getPartitionNumForTopic(_zkConnect, _topic);
       if (currentPartitionCount == _partitionNum.get()) {
+        LOG.info(_name + ": Topic named " + _topic + " does not exist.");
         return;
       }
       LOG.info(_name + ": Detected new partitions to monitor.");

--- a/src/main/java/com/linkedin/kmf/services/TopicManagementService.java
+++ b/src/main/java/com/linkedin/kmf/services/TopicManagementService.java
@@ -10,10 +10,9 @@
 
 package com.linkedin.kmf.services;
 
-import com.linkedin.kmf.common.TopicFactory;
+import com.linkedin.kmf.topicfactory.TopicFactory;
 import com.linkedin.kmf.services.configs.CommonServiceConfig;
 import com.linkedin.kmf.services.configs.TopicManagementServiceConfig;
-import com.oracle.tools.packager.Log;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
@@ -329,11 +328,11 @@ public class TopicManagementService implements Service  {
         _partitionsToBrokerRatio, new Properties());
     } catch (InstantiationException | InvocationTargetException | ClassNotFoundException | NoSuchMethodException
       | IllegalAccessException e) {
-      Log.error(_serviceName + ": failed to create topic, " + _topic + ".", e);
+      LOG.error(_serviceName + ": failed to create topic, " + _topic + ".", e);
     }
 
     TopicState topicState = topicState();
-    if(topicState == null) {
+    if (topicState == null) {
       throw new RuntimeException(_serviceName + ": topic, " + _topic + ", does not exist and could not be created.");
     }
     return topicState;

--- a/src/main/java/com/linkedin/kmf/services/configs/CommonServiceConfig.java
+++ b/src/main/java/com/linkedin/kmf/services/configs/CommonServiceConfig.java
@@ -27,4 +27,17 @@ public class CommonServiceConfig {
     + " created or rebalanced.  ceil(nBrokers * partitionsToBrokerRatio) is used to determine the actual number of "
     + "partitions when partitions are added or removed.";
 
+  public static final String TOPIC_REPLICATION_FACTOR_CONFIG = "topic-management.replicationFactor";
+  public static final String TOPIC_REPLICATION_FACTOR_DOC = "When a topic is created automatically this is the "
+      + "replication factor used.";
+
+  public static final String TOPIC_CREATION_ENABLED_CONFIG = "topic-management.topicCreationEnabled";
+  public static final String TOPIC_CREATION_ENABLED_DOC = "When true this automatically creates the topic mentioned by \"" +
+      TOPIC_CONFIG + "\" with replication factor \"" + TOPIC_REPLICATION_FACTOR_CONFIG + "and min ISR of max(" +
+      TOPIC_REPLICATION_FACTOR_CONFIG + "-1, 1) with number of brokers * \"" + PARTITIONS_TO_BROKER_RATO_CONFIG + "\" partitions.";
+
+  public static final String TOPIC_FACTORY_CONFIG = "topic-management.topicFactory.class.name";
+  public static final String TOPIC_FACTORY_DOC = "The name of the class used to create topics.  This class must implement "
+      + com.linkedin.kmf.common.TopicFactory.class.getName() + ".";
+
 }

--- a/src/main/java/com/linkedin/kmf/services/configs/CommonServiceConfig.java
+++ b/src/main/java/com/linkedin/kmf/services/configs/CommonServiceConfig.java
@@ -21,23 +21,4 @@ public class CommonServiceConfig {
 
   public static final String TOPIC_CONFIG = "topic";
   public static final String TOPIC_DOC = "Topic to be used by the service.";
-
-  public static final String PARTITIONS_TO_BROKER_RATO_CONFIG = "topic-management.partitionsToBrokersRatio";
-  public static final String PARTITIONS_TO_BROKER_RATIO_DOC = "Determines the number of partitions per broker when a topic is"
-    + " created or rebalanced.  ceil(nBrokers * partitionsToBrokerRatio) is used to determine the actual number of "
-    + "partitions when partitions are added or removed.";
-
-  public static final String TOPIC_REPLICATION_FACTOR_CONFIG = "topic-management.replicationFactor";
-  public static final String TOPIC_REPLICATION_FACTOR_DOC = "When a topic is created automatically this is the "
-      + "replication factor used.";
-
-  public static final String TOPIC_CREATION_ENABLED_CONFIG = "topic-management.topicCreationEnabled";
-  public static final String TOPIC_CREATION_ENABLED_DOC = "When true this automatically creates the topic mentioned by \"" +
-      TOPIC_CONFIG + "\" with replication factor \"" + TOPIC_REPLICATION_FACTOR_CONFIG + "and min ISR of max(" +
-      TOPIC_REPLICATION_FACTOR_CONFIG + "-1, 1) with number of brokers * \"" + PARTITIONS_TO_BROKER_RATO_CONFIG + "\" partitions.";
-
-  public static final String TOPIC_FACTORY_CONFIG = "topic-management.topicFactory.class.name";
-  public static final String TOPIC_FACTORY_DOC = "The name of the class used to create topics.  This class must implement "
-      + com.linkedin.kmf.common.TopicFactory.class.getName() + ".";
-
 }

--- a/src/main/java/com/linkedin/kmf/services/configs/ProduceServiceConfig.java
+++ b/src/main/java/com/linkedin/kmf/services/configs/ProduceServiceConfig.java
@@ -57,17 +57,6 @@ public class ProduceServiceConfig extends AbstractConfig {
   public static final String TOPIC_REPLICATION_FACTOR_DOC = "When a topic is created automatically this is the "
     + "replication factor used.";
 
-  public static final String TOPIC_FACTORY_CONFIG = "topic-management.topicFactory.class.name";
-  public static final String TOPIC_FACTORY_DOC = "The name of the class used to create topics.  This class must implement "
-    + TopicFactory.class.getName() + ".";
-
-  public static final String TOPIC_CREATION_ENABLED_CONFIG = "produce.topic.topicCreationEnabled";
-  public static final String TOPIC_CREATION_ENABLED_DOC = "When true this automatically creates the topic mentioned by \"" +
-      TOPIC_CONFIG + "\" with replication factor \"" + TOPIC_REPLICATION_FACTOR_CONFIG
-    + "and min ISR of max(" + TOPIC_REPLICATION_FACTOR_CONFIG + "-1, 1) with number of brokers * \"" +
-    CommonServiceConfig.PARTITIONS_TO_BROKER_RATO_CONFIG + "\" partitions.";
-
-
   static {
     CONFIG = new ConfigDef().define(ZOOKEEPER_CONNECT_CONFIG,
                                     ConfigDef.Type.STRING,
@@ -82,11 +71,6 @@ public class ProduceServiceConfig extends AbstractConfig {
                                     "kafka-monitor-topic",
                                     ConfigDef.Importance.MEDIUM,
                                     TOPIC_DOC)
-                            .define(TOPIC_CREATION_ENABLED_CONFIG,
-                                    ConfigDef.Type.BOOLEAN,
-                                    true,
-                                    ConfigDef.Importance.MEDIUM,
-                                    TOPIC_CREATION_ENABLED_DOC)
                             .define(PRODUCER_CLASS_CONFIG,
                                     ConfigDef.Type.STRING,
                                     NewProducer.class.getCanonicalName(),
@@ -130,12 +114,16 @@ public class ProduceServiceConfig extends AbstractConfig {
                                     atLeast(1.0),
                                     ConfigDef.Importance.LOW,
                                     CommonServiceConfig.PARTITIONS_TO_BROKER_RATIO_DOC)
-                            .define(TOPIC_FACTORY_CONFIG,
+                            .define(CommonServiceConfig.TOPIC_FACTORY_CONFIG,
                                     ConfigDef.Type.STRING,
                                     DefaultTopicFactory.class.getCanonicalName(),
                                     ConfigDef.Importance.LOW,
-                                    TOPIC_FACTORY_DOC);
-
+                                    CommonServiceConfig.TOPIC_FACTORY_DOC)
+                            .define(CommonServiceConfig.TOPIC_CREATION_ENABLED_CONFIG,
+                                    ConfigDef.Type.BOOLEAN,
+                                    true,
+                                    ConfigDef.Importance.LOW,
+                                    CommonServiceConfig.TOPIC_CREATION_ENABLED_DOC);
   }
 
   public ProduceServiceConfig(Map<?, ?> props) {

--- a/src/main/java/com/linkedin/kmf/services/configs/ProduceServiceConfig.java
+++ b/src/main/java/com/linkedin/kmf/services/configs/ProduceServiceConfig.java
@@ -31,9 +31,6 @@ public class ProduceServiceConfig extends AbstractConfig {
   public static final String TOPIC_CONFIG = CommonServiceConfig.TOPIC_CONFIG;
   public static final String TOPIC_DOC = CommonServiceConfig.TOPIC_DOC;
 
-  public static final String TOPIC_POLL_DELAY_CONFIG = "produce.topic.poll.delay";
-  public static final String TOPIC_POLL_DELAY_DOC = "The gap in ms between attempting to poll for a topic if it has not been created yet.";
-
   public static final String PRODUCER_CLASS_CONFIG = "produce.producer.class";
   public static final String PRODUCER_CLASS_DOC = "Producer class that will be instantiated as producer in the produce service. "
                                                   + "It can be NewProducer, or full class name of any class that implements the KMBaseProducer interface. ";
@@ -104,12 +101,7 @@ public class ProduceServiceConfig extends AbstractConfig {
                                     5,
                                     atLeast(1),
                                     ConfigDef.Importance.LOW,
-                                    PRODUCE_THREAD_NUM_DOC)
-                            .define(TOPIC_POLL_DELAY_CONFIG,
-                                    ConfigDef.Type.INT,
-                                    1000,
-                                    ConfigDef.Importance.LOW,
-                                    TOPIC_POLL_DELAY_DOC);
+                                    PRODUCE_THREAD_NUM_DOC);
   }
 
   public ProduceServiceConfig(Map<?, ?> props) {

--- a/src/main/java/com/linkedin/kmf/services/configs/ProduceServiceConfig.java
+++ b/src/main/java/com/linkedin/kmf/services/configs/ProduceServiceConfig.java
@@ -31,6 +31,9 @@ public class ProduceServiceConfig extends AbstractConfig {
   public static final String TOPIC_CONFIG = CommonServiceConfig.TOPIC_CONFIG;
   public static final String TOPIC_DOC = CommonServiceConfig.TOPIC_DOC;
 
+  public static final String TOPIC_POLL_DELAY_CONFIG = "produce.topic.poll.delay";
+  public static final String TOPIC_POLL_DELAY_DOC = "The gap in ms between attempting to poll for a topic if it has not been created yet.";
+
   public static final String PRODUCER_CLASS_CONFIG = "produce.producer.class";
   public static final String PRODUCER_CLASS_DOC = "Producer class that will be instantiated as producer in the produce service. "
                                                   + "It can be NewProducer, or full class name of any class that implements the KMBaseProducer interface. ";
@@ -102,28 +105,11 @@ public class ProduceServiceConfig extends AbstractConfig {
                                     atLeast(1),
                                     ConfigDef.Importance.LOW,
                                     PRODUCE_THREAD_NUM_DOC)
-                            .define(TOPIC_REPLICATION_FACTOR_CONFIG,
+                            .define(TOPIC_POLL_DELAY_CONFIG,
                                     ConfigDef.Type.INT,
-                                    1,
-                                    atLeast(1),
+                                    1000,
                                     ConfigDef.Importance.LOW,
-                                    TOPIC_REPLICATION_FACTOR_DOC)
-                            .define(CommonServiceConfig.PARTITIONS_TO_BROKER_RATO_CONFIG,
-                                    ConfigDef.Type.DOUBLE,
-                                    2.0,
-                                    atLeast(1.0),
-                                    ConfigDef.Importance.LOW,
-                                    CommonServiceConfig.PARTITIONS_TO_BROKER_RATIO_DOC)
-                            .define(CommonServiceConfig.TOPIC_FACTORY_CONFIG,
-                                    ConfigDef.Type.STRING,
-                                    DefaultTopicFactory.class.getCanonicalName(),
-                                    ConfigDef.Importance.LOW,
-                                    CommonServiceConfig.TOPIC_FACTORY_DOC)
-                            .define(CommonServiceConfig.TOPIC_CREATION_ENABLED_CONFIG,
-                                    ConfigDef.Type.BOOLEAN,
-                                    true,
-                                    ConfigDef.Importance.LOW,
-                                    CommonServiceConfig.TOPIC_CREATION_ENABLED_DOC);
+                                    TOPIC_POLL_DELAY_DOC);
   }
 
   public ProduceServiceConfig(Map<?, ?> props) {

--- a/src/main/java/com/linkedin/kmf/services/configs/ProduceServiceConfig.java
+++ b/src/main/java/com/linkedin/kmf/services/configs/ProduceServiceConfig.java
@@ -9,12 +9,10 @@
  */
 package com.linkedin.kmf.services.configs;
 
-import com.linkedin.kmf.topicfactory.DefaultTopicFactory;
 import com.linkedin.kmf.producer.NewProducer;
-import com.linkedin.kmf.topicfactory.TopicFactory;
+import java.util.Map;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
-import java.util.Map;
 
 import static org.apache.kafka.common.config.ConfigDef.Range.atLeast;
 
@@ -52,10 +50,6 @@ public class ProduceServiceConfig extends AbstractConfig {
 
   public static final String PRODUCER_PROPS_CONFIG = "produce.producer.props";
   public static final String PRODUCER_PROPS_DOC = "The properties used to config producer in produce service.";
-
-  public static final String TOPIC_REPLICATION_FACTOR_CONFIG = "topic-management.replicationFactor";
-  public static final String TOPIC_REPLICATION_FACTOR_DOC = "When a topic is created automatically this is the "
-    + "replication factor used.";
 
   static {
     CONFIG = new ConfigDef().define(ZOOKEEPER_CONNECT_CONFIG,

--- a/src/main/java/com/linkedin/kmf/services/configs/TopicManagementServiceConfig.java
+++ b/src/main/java/com/linkedin/kmf/services/configs/TopicManagementServiceConfig.java
@@ -58,7 +58,18 @@ public class TopicManagementServiceConfig extends AbstractConfig {
               2.0,
               atLeast(1),
               ConfigDef.Importance.LOW,
-              CommonServiceConfig.PARTITIONS_TO_BROKER_RATIO_DOC);
+              CommonServiceConfig.PARTITIONS_TO_BROKER_RATIO_DOC)
+      .define(CommonServiceConfig.TOPIC_CREATION_ENABLED_CONFIG,
+          ConfigDef.Type.BOOLEAN,
+          true,
+          ConfigDef.Importance.LOW,
+          CommonServiceConfig.TOPIC_CREATION_ENABLED_DOC)
+      .define(CommonServiceConfig.TOPIC_REPLICATION_FACTOR_CONFIG,
+          ConfigDef.Type.INT,
+          1,
+          atLeast(1),
+          ConfigDef.Importance.LOW,
+          CommonServiceConfig.TOPIC_REPLICATION_FACTOR_DOC);
   }
 
   public TopicManagementServiceConfig(Map<?, ?> props) {

--- a/src/main/java/com/linkedin/kmf/services/configs/TopicManagementServiceConfig.java
+++ b/src/main/java/com/linkedin/kmf/services/configs/TopicManagementServiceConfig.java
@@ -12,6 +12,7 @@ package com.linkedin.kmf.services.configs;
 import java.util.Map;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
+
 import static org.apache.kafka.common.config.ConfigDef.Range.atLeast;
 
 
@@ -30,6 +31,20 @@ public class TopicManagementServiceConfig extends AbstractConfig {
   public static final String REBALANCE_INTERVAL_MS_CONFIG = "topic-management.rebalance.interval.ms";
   public static final String REBALANCE_INTERVAL_MS_DOC = "The gap in ms between the times the cluster balance on the "
     + "monitored topic is checked.  Set this to a large value to disable automatic topic rebalance.";
+
+  public static final String PARTITIONS_TO_BROKER_RATIO_CONFIG = "topic-management.partitionsToBrokersRatio";
+  public static final String PARTITIONS_TO_BROKER_RATIO_DOC = "Determines the number of partitions per broker when a topic is"
+      + " created or rebalanced.  ceil(nBrokers * partitionsToBrokerRatio) is used to determine the actual number of "
+      + "partitions when partitions are added or removed.";
+
+  public static final String TOPIC_REPLICATION_FACTOR_CONFIG = "topic-management.replicationFactor";
+  public static final String TOPIC_REPLICATION_FACTOR_DOC = "When a topic is created automatically this is the "
+      + "replication factor used.";
+
+  public static final String TOPIC_CREATION_ENABLED_CONFIG = "topic-management.topicCreationEnabled";
+  public static final String TOPIC_CREATION_ENABLED_DOC = "When true this automatically creates the topic mentioned by \"" +
+      CommonServiceConfig.TOPIC_CONFIG + "\" with replication factor \"" + TOPIC_REPLICATION_FACTOR_CONFIG + "and min ISR of max(" +
+      TOPIC_REPLICATION_FACTOR_CONFIG + "-1, 1) with number of brokers * \"" + PARTITIONS_TO_BROKER_RATIO_CONFIG + "\" partitions.";
 
   static {
     CONFIG = new ConfigDef()
@@ -53,23 +68,23 @@ public class TopicManagementServiceConfig extends AbstractConfig {
               1000 * 60 * 10,
               atLeast(10),
               ConfigDef.Importance.LOW, REBALANCE_INTERVAL_MS_DOC)
-      .define(CommonServiceConfig.PARTITIONS_TO_BROKER_RATO_CONFIG,
+      .define(PARTITIONS_TO_BROKER_RATIO_CONFIG,
               ConfigDef.Type.DOUBLE,
               2.0,
               atLeast(1),
               ConfigDef.Importance.LOW,
-              CommonServiceConfig.PARTITIONS_TO_BROKER_RATIO_DOC)
-      .define(CommonServiceConfig.TOPIC_CREATION_ENABLED_CONFIG,
-          ConfigDef.Type.BOOLEAN,
-          true,
-          ConfigDef.Importance.LOW,
-          CommonServiceConfig.TOPIC_CREATION_ENABLED_DOC)
-      .define(CommonServiceConfig.TOPIC_REPLICATION_FACTOR_CONFIG,
-          ConfigDef.Type.INT,
-          1,
-          atLeast(1),
-          ConfigDef.Importance.LOW,
-          CommonServiceConfig.TOPIC_REPLICATION_FACTOR_DOC);
+              PARTITIONS_TO_BROKER_RATIO_DOC)
+      .define(TOPIC_CREATION_ENABLED_CONFIG,
+              ConfigDef.Type.BOOLEAN,
+              true,
+              ConfigDef.Importance.LOW,
+              TOPIC_CREATION_ENABLED_DOC)
+      .define(TOPIC_REPLICATION_FACTOR_CONFIG,
+              ConfigDef.Type.INT,
+              1,
+              atLeast(1),
+              ConfigDef.Importance.LOW,
+              TOPIC_REPLICATION_FACTOR_DOC);
   }
 
   public TopicManagementServiceConfig(Map<?, ?> props) {

--- a/src/main/java/com/linkedin/kmf/services/configs/TopicManagementServiceConfig.java
+++ b/src/main/java/com/linkedin/kmf/services/configs/TopicManagementServiceConfig.java
@@ -9,6 +9,8 @@
  */
 package com.linkedin.kmf.services.configs;
 
+import com.linkedin.kmf.common.DefaultTopicFactory;
+import com.linkedin.kmf.common.TopicFactory;
 import java.util.Map;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
@@ -45,6 +47,10 @@ public class TopicManagementServiceConfig extends AbstractConfig {
   public static final String TOPIC_CREATION_ENABLED_DOC = "When true this automatically creates the topic mentioned by \"" +
       CommonServiceConfig.TOPIC_CONFIG + "\" with replication factor \"" + TOPIC_REPLICATION_FACTOR_CONFIG + "and min ISR of max(" +
       TOPIC_REPLICATION_FACTOR_CONFIG + "-1, 1) with number of brokers * \"" + PARTITIONS_TO_BROKER_RATIO_CONFIG + "\" partitions.";
+
+  public static final String TOPIC_FACTORY_CONFIG = "topic-management.topicFactory.class.name";
+  public static final String TOPIC_FACTORY_DOC = "The name of the class used to create topics.  This class must implement "
+      + TopicFactory.class.getName() + ".";
 
   static {
     CONFIG = new ConfigDef()
@@ -84,7 +90,12 @@ public class TopicManagementServiceConfig extends AbstractConfig {
               1,
               atLeast(1),
               ConfigDef.Importance.LOW,
-              TOPIC_REPLICATION_FACTOR_DOC);
+              TOPIC_REPLICATION_FACTOR_DOC)
+      .define(TOPIC_FACTORY_CONFIG,
+              ConfigDef.Type.STRING,
+              DefaultTopicFactory.class.getCanonicalName(),
+              ConfigDef.Importance.LOW,
+              TOPIC_FACTORY_DOC);
   }
 
   public TopicManagementServiceConfig(Map<?, ?> props) {

--- a/src/main/java/com/linkedin/kmf/services/configs/TopicManagementServiceConfig.java
+++ b/src/main/java/com/linkedin/kmf/services/configs/TopicManagementServiceConfig.java
@@ -9,8 +9,8 @@
  */
 package com.linkedin.kmf.services.configs;
 
-import com.linkedin.kmf.common.DefaultTopicFactory;
-import com.linkedin.kmf.common.TopicFactory;
+import com.linkedin.kmf.topicfactory.DefaultTopicFactory;
+import com.linkedin.kmf.topicfactory.TopicFactory;
 import java.util.Map;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;

--- a/src/main/java/com/linkedin/kmf/tests/BasicEndToEndTest.java
+++ b/src/main/java/com/linkedin/kmf/tests/BasicEndToEndTest.java
@@ -207,7 +207,7 @@ public class BasicEndToEndTest implements Test {
       .type(Boolean.class)
       .metavar("AUTO_TOPIC_CREATION_ENABLED")
       .dest("autoTopicCreationEnabled")
-      .help(CommonServiceConfig.TOPIC_CREATION_ENABLED_DOC);
+      .help(TopicManagementServiceConfig.TOPIC_CREATION_ENABLED_DOC);
 
     parser.addArgument("--topic-rebalance-interval-ms")
       .action(store())
@@ -247,7 +247,7 @@ public class BasicEndToEndTest implements Test {
     if (res.getString("producerConfig") != null)
       props.put(ProduceServiceConfig.PRODUCER_PROPS_CONFIG, Utils.loadProps(res.getString("producerConfig")));
     if (res.getBoolean("autoTopicCreationEnabled") != null)
-      props.put(CommonServiceConfig.TOPIC_CREATION_ENABLED_CONFIG, res.getBoolean("autoTopicCreationEnabled"));
+      props.put(TopicManagementServiceConfig.TOPIC_CREATION_ENABLED_CONFIG, res.getBoolean("autoTopicCreationEnabled"));
     if (res.getInt("rebalanceMs") != null)
       props.put(TopicManagementServiceConfig.REBALANCE_INTERVAL_MS_CONFIG, res.getInt("rebalanceMs"));
 

--- a/src/main/java/com/linkedin/kmf/tests/BasicEndToEndTest.java
+++ b/src/main/java/com/linkedin/kmf/tests/BasicEndToEndTest.java
@@ -13,7 +13,6 @@ import com.linkedin.kmf.services.TopicManagementService;
 import com.linkedin.kmf.services.configs.ConsumeServiceConfig;
 import com.linkedin.kmf.services.configs.DefaultMetricsReporterServiceConfig;
 import com.linkedin.kmf.services.configs.ProduceServiceConfig;
-import com.linkedin.kmf.services.configs.CommonServiceConfig;
 import com.linkedin.kmf.services.ConsumeService;
 import com.linkedin.kmf.services.JettyService;
 import com.linkedin.kmf.services.JolokiaService;

--- a/src/main/java/com/linkedin/kmf/tests/BasicEndToEndTest.java
+++ b/src/main/java/com/linkedin/kmf/tests/BasicEndToEndTest.java
@@ -13,6 +13,7 @@ import com.linkedin.kmf.services.TopicManagementService;
 import com.linkedin.kmf.services.configs.ConsumeServiceConfig;
 import com.linkedin.kmf.services.configs.DefaultMetricsReporterServiceConfig;
 import com.linkedin.kmf.services.configs.ProduceServiceConfig;
+import com.linkedin.kmf.services.configs.CommonServiceConfig;
 import com.linkedin.kmf.services.ConsumeService;
 import com.linkedin.kmf.services.JettyService;
 import com.linkedin.kmf.services.JolokiaService;
@@ -56,16 +57,16 @@ public class BasicEndToEndTest implements Test {
 
   public BasicEndToEndTest(Map<String, Object> props, String name) throws Exception {
     _name = name;
+    _topicManagementService = new TopicManagementService(props, name);
     _produceService = new ProduceService(props, name);
     _consumeService = new ConsumeService(props, name);
-    _topicManagementService = new TopicManagementService(props, name);
   }
 
   @Override
   public void start() {
+    _topicManagementService.start();
     _produceService.start();
     _consumeService.start();
-    _topicManagementService.start();
     LOG.info(_name + "/BasicEndToEndTest started");
   }
 
@@ -206,7 +207,7 @@ public class BasicEndToEndTest implements Test {
       .type(Boolean.class)
       .metavar("AUTO_TOPIC_CREATION_ENABLED")
       .dest("autoTopicCreationEnabled")
-      .help(ProduceServiceConfig.TOPIC_CREATION_ENABLED_DOC);
+      .help(CommonServiceConfig.TOPIC_CREATION_ENABLED_DOC);
 
     parser.addArgument("--topic-rebalance-interval-ms")
       .action(store())
@@ -246,7 +247,7 @@ public class BasicEndToEndTest implements Test {
     if (res.getString("producerConfig") != null)
       props.put(ProduceServiceConfig.PRODUCER_PROPS_CONFIG, Utils.loadProps(res.getString("producerConfig")));
     if (res.getBoolean("autoTopicCreationEnabled") != null)
-      props.put(ProduceServiceConfig.TOPIC_CREATION_ENABLED_CONFIG, res.getBoolean("autoTopicCreationEnabled"));
+      props.put(CommonServiceConfig.TOPIC_CREATION_ENABLED_CONFIG, res.getBoolean("autoTopicCreationEnabled"));
     if (res.getInt("rebalanceMs") != null)
       props.put(TopicManagementServiceConfig.REBALANCE_INTERVAL_MS_CONFIG, res.getInt("rebalanceMs"));
 

--- a/src/test/java/com/linkedin/kmf/services/TopicManagementServiceTest.java
+++ b/src/test/java/com/linkedin/kmf/services/TopicManagementServiceTest.java
@@ -67,7 +67,7 @@ public class TopicManagementServiceTest {
     Assert.assertFalse(topicState.someBrokerMissingPartition());
     Assert.assertFalse(topicState.someBrokerWithoutLeader());
     Assert.assertTrue(topicState.insufficientPartitions());
-    Assert.assertEquals(topicState.replicationFactor(), 2);
+    Assert.assertEquals(topicState.currentReplicationFactor(), 2);
   }
 
 

--- a/src/test/java/com/linkedin/kmf/services/TopicManagementServiceTest.java
+++ b/src/test/java/com/linkedin/kmf/services/TopicManagementServiceTest.java
@@ -67,7 +67,7 @@ public class TopicManagementServiceTest {
     Assert.assertFalse(topicState.someBrokerMissingPartition());
     Assert.assertFalse(topicState.someBrokerWithoutLeader());
     Assert.assertTrue(topicState.insufficientPartitions());
-    Assert.assertEquals(topicState.currentReplicationFactor(), 2);
+    Assert.assertEquals(topicState.replicationFactor(), 2);
   }
 
 


### PR DESCRIPTION
Topic creation is now a responsibility of the TopicManagementService and the ProducerService will non-blocking wait to produce until the topic is created. 