### PR TITLE
KafkaMonitor should map class under Test package into App interface

### DIFF
--- a/src/main/java/com/linkedin/kmf/KafkaMonitor.java
+++ b/src/main/java/com/linkedin/kmf/KafkaMonitor.java
@@ -12,6 +12,7 @@ package com.linkedin.kmf;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linkedin.kmf.services.Service;
 import com.linkedin.kmf.apps.App;
+import com.linkedin.kmf.tests.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import java.io.BufferedReader;
@@ -42,7 +43,8 @@ public class KafkaMonitor {
         throw new IllegalArgumentException(name + " is not configured with " + CLASS_NAME_CONFIG);
       String className = (String) props.get(CLASS_NAME_CONFIG);
 
-      if (className.startsWith(App.class.getPackage().getName())) {
+      if (className.startsWith(App.class.getPackage().getName()) ||
+          className.startsWith(Test.class.getPackage().getName())) {
         App test = (App) Class.forName(className).getConstructor(Map.class, String.class).newInstance(props, name);
         _tests.put(name, test);
       } else {


### PR DESCRIPTION
If user specifies a class under test package in the kafka-monitor.properties, KafkaMonitor should instantiate an instance of this class and map it to the App interface. The patch fixed a bug where such class will be instantiated and mapped into the Service interface.