### PR TITLE
Allow ProduceService to start working sooner if the topic is created after ProduceService has started

### DIFF
--- a/src/main/java/com/linkedin/kmf/common/Utils.java
+++ b/src/main/java/com/linkedin/kmf/common/Utils.java
@@ -87,7 +87,6 @@ public class Utils {
     ZkUtils zkUtils = ZkUtils.apply(zkUrl, ZK_SESSION_TIMEOUT_MS, ZK_CONNECTION_TIMEOUT_MS, JaasUtils.isZkSecurityEnabled());
     try {
       if (AdminUtils.topicExists(zkUtils, topic)) {
-        LOG.debug("Monitoring topic \"" + topic + "\" already exists.");
         return getPartitionNumForTopic(zkUrl, topic);
       }
 
@@ -102,9 +101,9 @@ public class Utils {
 
       try {
         AdminUtils.createTopic(zkUtils, topic, partitionCount, replicationFactor, topicConfig, RackAwareMode.Enforced$.MODULE$);
-      } catch (TopicExistsException tee) {
+      } catch (TopicExistsException e) {
         //There is a race condition with the consumer.
-        LOG.debug("Monitoring topic \"" + topic + "\" already exists (caught exception).");
+        LOG.debug("Monitoring topic \"" + topic + "\" already exists", e);
         return getPartitionNumForTopic(zkUrl, topic);
       }
       LOG.info("Created monitoring topic \"" + topic + "\" with " + partitionCount + " partitions, min ISR of "

--- a/src/main/java/com/linkedin/kmf/common/Utils.java
+++ b/src/main/java/com/linkedin/kmf/common/Utils.java
@@ -87,7 +87,7 @@ public class Utils {
     ZkUtils zkUtils = ZkUtils.apply(zkUrl, ZK_SESSION_TIMEOUT_MS, ZK_CONNECTION_TIMEOUT_MS, JaasUtils.isZkSecurityEnabled());
     try {
       if (AdminUtils.topicExists(zkUtils, topic)) {
-        LOG.info("Monitoring topic \"" + topic + "\" already exists.");
+        LOG.debug("Monitoring topic \"" + topic + "\" already exists.");
         return getPartitionNumForTopic(zkUrl, topic);
       }
 
@@ -104,7 +104,7 @@ public class Utils {
         AdminUtils.createTopic(zkUtils, topic, partitionCount, replicationFactor, topicConfig, RackAwareMode.Enforced$.MODULE$);
       } catch (TopicExistsException tee) {
         //There is a race condition with the consumer.
-        LOG.info("Monitoring topic \"" + topic + "\" already exists (caught exception).");
+        LOG.debug("Monitoring topic \"" + topic + "\" already exists (caught exception).");
         return getPartitionNumForTopic(zkUrl, topic);
       }
       LOG.info("Created monitoring topic \"" + topic + "\" with " + partitionCount + " partitions, min ISR of "

--- a/src/main/java/com/linkedin/kmf/services/ProduceService.java
+++ b/src/main/java/com/linkedin/kmf/services/ProduceService.java
@@ -150,7 +150,7 @@ public class ProduceService implements Service {
   public synchronized void start() {
     if (_running.compareAndSet(false, true)) {
       initializeStateForPartitions();
-      _handleNewPartitionsExecutor.scheduleWithFixedDelay(new NewPartitionHandler(), 40_000, 40_000, TimeUnit.MILLISECONDS);
+      _handleNewPartitionsExecutor.scheduleWithFixedDelay(new NewPartitionHandler(), 1000, 30000, TimeUnit.MILLISECONDS);
       LOG.info(_name + "/ProduceService started");
     }
   }

--- a/src/main/java/com/linkedin/kmf/services/TopicManagementService.java
+++ b/src/main/java/com/linkedin/kmf/services/TopicManagementService.java
@@ -180,8 +180,9 @@ public class TopicManagementService implements Service  {
           LOG.info(_serviceName + " can't determine replication factor of monitored topic " + _topic + ".  Will try rebalance later.");
           return;
         } else if (currentReplicationFactor != _configuredTopicReplicationFactor) {
-          throw new RuntimeException(_serviceName + ": replication factor given as configuration "
-              + TopicManagementServiceConfig.TOPIC_REPLICATION_FACTOR_CONFIG + " does not match the topic's current replication factor.");
+          throw new RuntimeException(_serviceName + ": replication factor " + _configuredTopicReplicationFactor +
+              " from config " + TopicManagementServiceConfig.TOPIC_REPLICATION_FACTOR_CONFIG +
+              " does not match the topic's current replication factor " + currentReplicationFactor);
         }
 
         if (topicState.someBrokerWithoutLeader() || topicState.someBrokerMissingPartition() || topicState.insufficientPartitions()) {


### PR DESCRIPTION
Currently if we start KafkaMonitor without first creating the topic, the KafkaMonitor's metric will be NAN for up to 40 seconds. This is because the topic may be created after ProduceService starts and the ProduceService only detect topic creation or partition expansion every 40 seconds. This patch reduces the expected time to wait by scheduling the detection to run 1 seconds after ProduceService starts.

Also, we should catch and swallow ToipcExistsException in the TopicManagementService because consumer in the ConsumeService may create the topic when consumer subscribes to the topic if topic auto creation is enabled.