### PR TITLE
Docker build hardening

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,9 +17,6 @@ MAINTAINER coffeepac@gmail.com
 
 WORKDIR /opt/kafka-monitor
 ADD build/ build/
-ADD core/build/ core/build/
-ADD services/build/ services/build/
-ADD tests/build/ tests/build/
 ADD bin/kafka-monitor-start.sh bin/kafka-monitor-start.sh
 ADD bin/kmf-run-class.sh bin/kmf-run-class.sh
 ADD config/kafka-monitor.properties config/kafka-monitor.properties

--- a/docker/kafka-monitor-docker-entry.sh
+++ b/docker/kafka-monitor-docker-entry.sh
@@ -15,7 +15,13 @@
 
 set -x
 
+# SIGTERM-handler
+trap 'pkill java; exit 130' SIGINT
+trap 'pkill java; exit 143' SIGTERM
+
 #  wait for DNS services to be available
 sleep 10
 
-bin/kafka-monitor-start.sh config/kafka-monitor.properties
+bin/kafka-monitor-start.sh config/kafka-monitor.properties &
+
+wait $!


### PR DESCRIPTION
- removes some non-existing folders from being added to the Docker image
- properly handle signals in Docker start script so that the Kafka Monitor process is getting stopped when receiving a SIGINT or SIGTERM signal.