### PR TITLE
KafkaMonitor logger additivity in 0.8.2.2

### DIFF
--- a/config/log4j.properties
+++ b/config/log4j.properties
@@ -19,7 +19,7 @@ log4j.appender.kafkaClientAppender.layout=org.apache.log4j.PatternLayout
 log4j.appender.kafkaClientAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
 
 log4j.logger.com.linkedin.kmf.core.KafkaMonitor=INFO, stdout
-log4j.additivity.kmf.tools.KafkaMonitor=false
+log4j.additivity.com.linkedin.kmf.core.KafkaMonitor=false
 
 log4j.logger.org.apache.kafka=WARN, kafkaClientAppender
 log4j.additivity.org.apache.kafka=false


### PR DESCRIPTION
Correct the log4j additivity for com.linkedin.kmf.core.KafkaMonitor.