### PR TITLE
export to prometheus

### DIFF
--- a/config/prometheus-exporter.yaml
+++ b/config/prometheus-exporter.yaml
@@ -1,0 +1,7 @@
+---
+lowercaseOutputName: true
+rules:
+- pattern : kmf<type=(.+)><>([\w\d-]+)
+  name: kmf_$1_$2
+- pattern : kmf.services<type=(.+), name=(.+)><>([\w\d-]+)
+  name: kmf_services_$1_$2_$3


### PR DESCRIPTION
export to prometheus supported format using jmx exporter with this config file

with this config file, you will get something like following:

```
# HELP kmf_services_consume_service_single_cluster_monitor_records_delay_ms_avg The average latency of records from producer to consumer (kmf.services<type=consume-service, name=single-cluster-monitor><>records-delay-ms-avg)
# TYPE kmf_services_consume_service_single_cluster_monitor_records_delay_ms_avg gauge
kmf_services_consume_service_single_cluster_monitor_records_delay_ms_avg 1.674074074074074
# HELP kmf_services_consume_service_single_cluster_monitor_records_lost_total The total number of records that are lost (kmf.services<type=consume-service, name=single-cluster-monitor><>records-lost-total)
# TYPE kmf_services_consume_service_single_cluster_monitor_records_lost_total gauge
kmf_services_consume_service_single_cluster_monitor_records_lost_total 0.0
# HELP kmf_services_consume_service_single_cluster_monitor_consume_error_total The total number of errors (kmf.services<type=consume-service, name=single-cluster-monitor><>consume-error-total)
# TYPE kmf_services_consume_service_single_cluster_monitor_consume_error_total gauge
kmf_services_consume_service_single_cluster_monitor_consume_error_total 0.0
# HELP kmf_kafka_metrics_count_count total number of registered metrics (kmf<type=kafka-metrics-count><>count)
# TYPE kmf_kafka_metrics_count_count gauge
kmf_kafka_metrics_count_count 2.0
# HELP kmf_services_consume_service_single_cluster_monitor_consume_availability_avg The average consume availability (kmf.services<type=consume-service, name=single-cluster-monitor><>consume-availability-avg)
# TYPE kmf_services_consume_service_single_cluster_monitor_consume_availability_avg gauge
kmf_services_consume_service_single_cluster_monitor_consume_availability_avg 1.0
# HELP kmf_services_consume_service_single_cluster_monitor_records_duplicated_rate The average number of records per second that are duplicated (kmf.services<type=consume-service, name=single-cluster-monitor><>records-duplicated-rate)
# TYPE kmf_services_consume_service_single_cluster_monitor_records_duplicated_rate gauge
kmf_services_consume_service_single_cluster_monitor_records_duplicated_rate 0.0
# HELP kmf_services_consume_service_single_cluster_monitor_records_consumed_rate The average number of records per second that are consumed (kmf.services<type=consume-service, name=single-cluster-monitor><>records-consumed-rate)
# TYPE kmf_services_consume_service_single_cluster_monitor_records_consumed_rate gauge
kmf_services_consume_service_single_cluster_monitor_records_consumed_rate 4.51693851944793
# HELP kmf_services_consume_service_single_cluster_monitor_records_delayed_rate The average number of records per second that are either lost or arrive after maximum allowed latency under SLA (kmf.services<type=consume-service, name=single-cluster-monitor><>records-delayed-rate)
# TYPE kmf_services_consume_service_single_cluster_monitor_records_delayed_rate gauge
kmf_services_consume_service_single_cluster_monitor_records_delayed_rate 0.0
# HELP kmf_services_produce_service_single_cluster_monitor_records_produced_rate_partition_2 The average number of records per second that are produced to this partition (kmf.services<type=produce-service, name=single-cluster-monitor><>records-produced-rate-partition-2)
# TYPE kmf_services_produce_service_single_cluster_monitor_records_produced_rate_partition_2 gauge
kmf_services_produce_service_single_cluster_monitor_records_produced_rate_partition_2 1.4426383506953182
# HELP kmf_services_consume_service_single_cluster_monitor_records_delay_ms_999th The 999th percentile latency of records from producer to consumer (kmf.services<type=consume-service, name=single-cluster-monitor><>records-delay-ms-999th)
# TYPE kmf_services_consume_service_single_cluster_monitor_records_delay_ms_999th gauge
kmf_services_consume_service_single_cluster_monitor_records_delay_ms_999th 11.0
# HELP kmf_services_produce_service_single_cluster_monitor_records_produced_rate_partition_3 The average number of records per second that are produced to this partition (kmf.services<type=produce-service, name=single-cluster-monitor><>records-produced-rate-partition-3)
# TYPE kmf_services_produce_service_single_cluster_monitor_records_produced_rate_partition_3 gauge
kmf_services_produce_service_single_cluster_monitor_records_produced_rate_partition_3 1.442662551164195
# HELP kmf_services_consume_service_single_cluster_monitor_records_delay_ms_max The maximum latency of records from producer to consumer (kmf.services<type=consume-service, name=single-cluster-monitor><>records-delay-ms-max)
# TYPE kmf_services_consume_service_single_cluster_monitor_records_delay_ms_max gauge
kmf_services_consume_service_single_cluster_monitor_records_delay_ms_max 11.0
# HELP kmf_services_produce_service_single_cluster_monitor_records_produced_rate_partition_0 The average number of records per second that are produced to this partition (kmf.services<type=produce-service, name=single-cluster-monitor><>records-produced-rate-partition-0)
# TYPE kmf_services_produce_service_single_cluster_monitor_records_produced_rate_partition_0 gauge
kmf_services_produce_service_single_cluster_monitor_records_produced_rate_partition_0 1.4426867524450186
# HELP kmf_services_produce_service_single_cluster_monitor_records_produced_rate_partition_1 The average number of records per second that are produced to this partition (kmf.services<type=produce-service, name=single-cluster-monitor><>records-produced-rate-partition-1)
# TYPE kmf_services_produce_service_single_cluster_monitor_records_produced_rate_partition_1 gauge
kmf_services_produce_service_single_cluster_monitor_records_produced_rate_partition_1 1.4426867524450186
# HELP kmf_services_produce_service_single_cluster_monitor_produce_error_rate The average number of errors per second (kmf.services<type=produce-service, name=single-cluster-monitor><>produce-error-rate)
# TYPE kmf_services_produce_service_single_cluster_monitor_produce_error_rate gauge
kmf_services_produce_service_single_cluster_monitor_produce_error_rate 0.0
# HELP kmf_services_consume_service_single_cluster_monitor_records_delay_ms_99th The 99th percentile latency of records from producer to consumer (kmf.services<type=consume-service, name=single-cluster-monitor><>records-delay-ms-99th)
# TYPE kmf_services_consume_service_single_cluster_monitor_records_delay_ms_99th gauge
kmf_services_consume_service_single_cluster_monitor_records_delay_ms_99th 11.0
# HELP kmf_services_produce_service_single_cluster_monitor_records_produced_rate_partition_4 The average number of records per second that are produced to this partition (kmf.services<type=produce-service, name=single-cluster-monitor><>records-produced-rate-partition-4)
# TYPE kmf_services_produce_service_single_cluster_monitor_records_produced_rate_partition_4 gauge
kmf_services_produce_service_single_cluster_monitor_records_produced_rate_partition_4 1.442662551164195
# HELP kmf_services_produce_service_single_cluster_monitor_produce_error_rate_partition_4 The average number of errors per second when producing to this partition (kmf.services<type=produce-service, name=single-cluster-monitor><>produce-error-rate-partition-4)
# TYPE kmf_services_produce_service_single_cluster_monitor_produce_error_rate_partition_4 gauge
kmf_services_produce_service_single_cluster_monitor_produce_error_rate_partition_4 0.0
# HELP kmf_services_produce_service_single_cluster_monitor_records_produced_total The total number of records that are produced (kmf.services<type=produce-service, name=single-cluster-monitor><>records-produced-total)
# TYPE kmf_services_produce_service_single_cluster_monitor_records_produced_total gauge
kmf_services_produce_service_single_cluster_monitor_records_produced_total 516.0
# HELP kmf_services_produce_service_single_cluster_monitor_records_produced_rate_partition_5 The average number of records per second that are produced to this partition (kmf.services<type=produce-service, name=single-cluster-monitor><>records-produced-rate-partition-5)
# TYPE kmf_services_produce_service_single_cluster_monitor_records_produced_rate_partition_5 gauge
kmf_services_produce_service_single_cluster_monitor_records_produced_rate_partition_5 1.442662551164195
# HELP kmf_services_produce_service_single_cluster_monitor_produce_error_rate_partition_5 The average number of errors per second when producing to this partition (kmf.services<type=produce-service, name=single-cluster-monitor><>produce-error-rate-partition-5)
# TYPE kmf_services_produce_service_single_cluster_monitor_produce_error_rate_partition_5 gauge
kmf_services_produce_service_single_cluster_monitor_produce_error_rate_partition_5 0.0
# HELP kmf_services_consume_service_single_cluster_monitor_records_duplicated_total The total number of records that are duplicated (kmf.services<type=consume-service, name=single-cluster-monitor><>records-duplicated-total)
# TYPE kmf_services_consume_service_single_cluster_monitor_records_duplicated_total gauge
kmf_services_consume_service_single_cluster_monitor_records_duplicated_total 0.0
# HELP kmf_services_produce_service_single_cluster_monitor_produce_error_rate_partition_2 The average number of errors per second when producing to this partition (kmf.services<type=produce-service, name=single-cluster-monitor><>produce-error-rate-partition-2)
# TYPE kmf_services_produce_service_single_cluster_monitor_produce_error_rate_partition_2 gauge
kmf_services_produce_service_single_cluster_monitor_produce_error_rate_partition_2 0.0
# HELP kmf_services_produce_service_single_cluster_monitor_produce_error_rate_partition_3 The average number of errors per second when producing to this partition (kmf.services<type=produce-service, name=single-cluster-monitor><>produce-error-rate-partition-3)
# TYPE kmf_services_produce_service_single_cluster_monitor_produce_error_rate_partition_3 gauge
kmf_services_produce_service_single_cluster_monitor_produce_error_rate_partition_3 0.0
# HELP kmf_services_produce_service_single_cluster_monitor_produce_error_rate_partition_0 The average number of errors per second when producing to this partition (kmf.services<type=produce-service, name=single-cluster-monitor><>produce-error-rate-partition-0)
# TYPE kmf_services_produce_service_single_cluster_monitor_produce_error_rate_partition_0 gauge
kmf_services_produce_service_single_cluster_monitor_produce_error_rate_partition_0 0.0
# HELP kmf_services_produce_service_single_cluster_monitor_produce_error_rate_partition_1 The average number of errors per second when producing to this partition (kmf.services<type=produce-service, name=single-cluster-monitor><>produce-error-rate-partition-1)
# TYPE kmf_services_produce_service_single_cluster_monitor_produce_error_rate_partition_1 gauge
kmf_services_produce_service_single_cluster_monitor_produce_error_rate_partition_1 0.0
# HELP kmf_services_produce_service_single_cluster_monitor_records_produced_rate The average number of records per second that are produced (kmf.services<type=produce-service, name=single-cluster-monitor><>records-produced-rate)
# TYPE kmf_services_produce_service_single_cluster_monitor_records_produced_rate gauge
kmf_services_produce_service_single_cluster_monitor_records_produced_rate 8.655975306985171
# HELP kmf_services_consume_service_single_cluster_monitor_records_lost_rate The average number of records per second that are lost (kmf.services<type=consume-service, name=single-cluster-monitor><>records-lost-rate)
# TYPE kmf_services_consume_service_single_cluster_monitor_records_lost_rate gauge
kmf_services_consume_service_single_cluster_monitor_records_lost_rate 0.0
# HELP kmf_services_produce_service_single_cluster_monitor_produce_delay_ms_max The maximum delay in ms for produce request (kmf.services<type=produce-service, name=single-cluster-monitor><>produce-delay-ms-max)
# TYPE kmf_services_produce_service_single_cluster_monitor_produce_delay_ms_max gauge
kmf_services_produce_service_single_cluster_monitor_produce_delay_ms_max 161.0
# HELP kmf_services_produce_service_single_cluster_monitor_produce_error_total The total number of errors (kmf.services<type=produce-service, name=single-cluster-monitor><>produce-error-total)
# TYPE kmf_services_produce_service_single_cluster_monitor_produce_error_total gauge
kmf_services_produce_service_single_cluster_monitor_produce_error_total 0.0
# HELP kmf_services_consume_service_single_cluster_monitor_records_consumed_total The total number of records that are consumed (kmf.services<type=consume-service, name=single-cluster-monitor><>records-consumed-total)
# TYPE kmf_services_consume_service_single_cluster_monitor_records_consumed_total gauge
kmf_services_consume_service_single_cluster_monitor_records_consumed_total 270.0
# HELP kmf_services_consume_service_single_cluster_monitor_consume_error_rate The average number of errors per second (kmf.services<type=consume-service, name=single-cluster-monitor><>consume-error-rate)
# TYPE kmf_services_consume_service_single_cluster_monitor_consume_error_rate gauge
kmf_services_consume_service_single_cluster_monitor_consume_error_rate 0.0
# HELP kmf_services_produce_service_single_cluster_monitor_produce_availability_avg The average produce availability (kmf.services<type=produce-service, name=single-cluster-monitor><>produce-availability-avg)
# TYPE kmf_services_produce_service_single_cluster_monitor_produce_availability_avg gauge
kmf_services_produce_service_single_cluster_monitor_produce_availability_avg 1.0
# HELP kmf_services_produce_service_single_cluster_monitor_produce_delay_ms_avg The average delay in ms for produce request (kmf.services<type=produce-service, name=single-cluster-monitor><>produce-delay-ms-avg)
# TYPE kmf_services_produce_service_single_cluster_monitor_produce_delay_ms_avg gauge
kmf_services_produce_service_single_cluster_monitor_produce_delay_ms_avg 2.643410852713178
# HELP kmf_services_consume_service_single_cluster_monitor_bytes_consumed_rate The average number of bytes per second that are consumed (kmf.services<type=consume-service, name=single-cluster-monitor><>bytes-consumed-rate)
# TYPE kmf_services_consume_service_single_cluster_monitor_bytes_consumed_rate gauge
kmf_services_consume_service_single_cluster_monitor_bytes_consumed_rate 925.3721313127919
# HELP kmf_services_consume_service_single_cluster_monitor_records_delayed_total The total number of records that are either lost or arrive after maximum allowed latency under SLA (kmf.services<type=consume-service, name=single-cluster-monitor><>records-delayed-total)
# TYPE kmf_services_consume_service_single_cluster_monitor_records_delayed_total gauge
kmf_services_consume_service_single_cluster_monitor_records_delayed_total 0.0
# HELP kmf_kafka_monitor_offline_runnable_count The number of Service/App that are not fully running (kmf<type=kafka-monitor><>offline-runnable-count)
# TYPE kmf_kafka_monitor_offline_runnable_count gauge
kmf_kafka_monitor_offline_runnable_count 0.0

```