### PR TITLE
Add support for reporting metrics to SignalFx

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,7 @@ allprojects {
 
   checkstyle {
     configFile = new File(rootDir, "checkstyle/checkstyle.xml")
+    configProperties = [ "suppressionFile" : new File(rootDir, "checkstyle/suppressions.xml") ]
   }
 
   test.dependsOn('checkstyleMain', 'checkstyleTest')

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ allprojects {
     compile 'org.jolokia:jolokia-jvm:1.3.3'
     compile 'net.savantly:graphite-client:1.1.0-RELEASE'
     compile 'com.timgroup:java-statsd-client:3.0.1'
+    compile 'com.signalfx.public:signalfx-codahale:0.0.47'
 
     testCompile 'org.testng:testng:6.8.8'
   }

--- a/checkstyle/checkstyle.xml
+++ b/checkstyle/checkstyle.xml
@@ -21,6 +21,10 @@
     <property name="header" value="/\*\*\nCopyright 2016 LinkedIn Corp. Licensed under the Apache License.*"/>
   </module>
 
+  <module name="SuppressionFilter">
+    <property name="file" value="${suppressionFile}"/>
+  </module>
+
   <module name="TreeWalker">
 
     <!-- code cleanup -->

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+
+<!DOCTYPE suppressions PUBLIC
+    "-//Puppy Crawl//DTD Suppressions 1.1//EN"
+    "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+
+<suppressions>
+    <suppress checks="RegexpHeader" files="SignalFx*" />
+</suppressions>

--- a/config/kafka-monitor.properties
+++ b/config/kafka-monitor.properties
@@ -133,6 +133,16 @@
 #    ]
 #  }
 
+#  Example signalfx-service to report metrics
+# "signalfx-service": {
+#   "class.name": "com.linkedin.kmf.services.SignalFxMetricsReporterService",
+#   "report.interval.sec": 1,
+#   "report.metric.dimensions": {
+#   },
+#   "report.signalfx.url": "",
+#   "report.signalfx.token" : ""
+# }
+
 }
 
 

--- a/src/main/java/com/linkedin/kmf/services/SignalFxMetricsReporterService.java
+++ b/src/main/java/com/linkedin/kmf/services/SignalFxMetricsReporterService.java
@@ -1,0 +1,189 @@
+/**
+ * Copyright 2016 LinkedIn Corp. Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.linkedin.kmf.services;
+
+import static com.linkedin.kmf.common.Utils.getMBeanAttributeValues;
+
+import java.net.URL;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.codahale.metrics.MetricRegistry;
+import com.linkedin.kmf.common.MbeanAttributeValue;
+import com.linkedin.kmf.services.configs.SignalFxMetricsReporterServiceConfig;
+import com.signalfx.codahale.metrics.SettableDoubleGauge;
+import com.signalfx.codahale.reporter.MetricMetadata;
+import com.signalfx.codahale.reporter.SignalFxReporter;
+import com.signalfx.endpoint.SignalFxEndpoint;
+
+public class SignalFxMetricsReporterService implements Service {
+  private static final Logger LOG = LoggerFactory.getLogger(SignalFxMetricsReporterService.class);
+
+  private final String _name;
+  private final List<String> _metricNames;
+  private final int _reportIntervalSec;
+  private final ScheduledExecutorService _executor;
+  private final MetricRegistry _metricRegistry;
+  private final SignalFxReporter _signalfxReporter;
+  private final String _signalfxUrl;
+  private final String _signalfxToken;
+
+  private MetricMetadata _metricMetadata;
+  private Map<String, SettableDoubleGauge> _metricMap;
+  private Map<String, String> _dimensionsMap;
+
+  public SignalFxMetricsReporterService(Map<String, Object> props, String name) throws Exception {
+    SignalFxMetricsReporterServiceConfig config = new SignalFxMetricsReporterServiceConfig(props);
+
+    _name = name;
+    _metricNames = config.getList(SignalFxMetricsReporterServiceConfig.REPORT_METRICS_CONFIG);
+    _reportIntervalSec = config.getInt(SignalFxMetricsReporterServiceConfig.REPORT_INTERVAL_SEC_CONFIG);
+    _signalfxUrl = config.getString(SignalFxMetricsReporterServiceConfig.REPORT_SIGNALFX_URL);
+    _signalfxToken = config.getString(SignalFxMetricsReporterServiceConfig.SIGNALFX_TOKEN);
+
+    if (StringUtils.isEmpty(_signalfxToken)) {
+      throw new IllegalArgumentException("SignalFx token is not configured");
+    }
+
+    _executor = Executors.newSingleThreadScheduledExecutor();
+    _metricRegistry = new MetricRegistry();
+    _metricMap = new HashMap<String, SettableDoubleGauge>();
+    _dimensionsMap = new HashMap<String, String>();
+    if (props.containsKey(SignalFxMetricsReporterServiceConfig.SIGNALFX_METRIC_DIMENSION)) {
+      _dimensionsMap = (Map<String, String>) props.get(SignalFxMetricsReporterServiceConfig.SIGNALFX_METRIC_DIMENSION);
+    }
+
+    SignalFxReporter.Builder sfxReportBuilder = new SignalFxReporter.Builder(
+        _metricRegistry,
+        _signalfxToken
+    );
+    if (!StringUtils.isEmpty(_signalfxUrl)) {
+      sfxReportBuilder.setEndpoint(getSignalFxEndpoint(_signalfxUrl));
+    }
+    _signalfxReporter = sfxReportBuilder.build();
+
+    _metricMetadata = _signalfxReporter.getMetricMetadata();
+  }
+
+  @Override
+  public synchronized void start() {
+    _signalfxReporter.start(_reportIntervalSec, TimeUnit.SECONDS);
+    _executor.scheduleAtFixedRate(new Runnable() {
+      @Override
+      public void run() {
+        try {
+          captureMetrics();
+        } catch (Exception e) {
+          LOG.error(_name + "/SignalFxMetricsReporterService failed to report metrics", e);
+        }
+      }
+    }, _reportIntervalSec, _reportIntervalSec, TimeUnit.SECONDS);
+    LOG.info("{}/SignalFxMetricsReporterService started", _name);
+  }
+
+  @Override
+  public synchronized void stop() {
+    _executor.shutdown();
+    _signalfxReporter.stop();
+    LOG.info("{}/SignalFxMetricsReporterService stopped", _name);
+  }
+
+  @Override
+  public boolean isRunning() {
+    return !_executor.isShutdown();
+  }
+
+  @Override
+  public void awaitShutdown() {
+    try {
+      _executor.awaitTermination(5, TimeUnit.MINUTES);
+    } catch (InterruptedException e) {
+      LOG.info("Thread interrupted when waiting for {}/SignalFxMetricsReporterService to shutdown", _name);
+    }
+    LOG.info("{}/SignalFxMetricsReporterService shutdown completed", _name);
+  }
+
+  private SignalFxEndpoint getSignalFxEndpoint(String urlStr) throws Exception {
+    URL url = new URL(urlStr);
+    return new SignalFxEndpoint(url.getProtocol(), url.getHost(), url.getPort());
+  }
+
+  private String generateSignalFxMetricName(String bean, String attribute) {
+    String service = bean.split(":")[1];
+    String serviceType = service.split(",")[1].split("=")[1];
+    return String.format("%s.%s", serviceType, attribute);
+  }
+
+  private void captureMetrics() {
+    for (String metricName : _metricNames) {
+      int index = metricName.lastIndexOf(':');
+      String mbeanExpr = metricName.substring(0, index);
+      String attributeExpr = metricName.substring(index + 1);
+
+      List<MbeanAttributeValue> attributeValues = getMBeanAttributeValues(mbeanExpr, attributeExpr);
+
+      for (final MbeanAttributeValue attributeValue : attributeValues) {
+        String metric = attributeValue.toString();
+        String key = metric.substring(0, metric.lastIndexOf("="));
+        String[] parts = key.split(",");
+        if (parts.length < 2) {
+          continue;
+        }
+        parts = parts[0].split("=");
+        if (parts.length < 2 || !parts[1].contains("cluster-monitor")) {
+          continue;
+        }
+        setMetricValue(attributeValue);
+      }
+    }
+  }
+
+  private void setMetricValue(MbeanAttributeValue attributeValue) {
+    String key = attributeValue.mbean() + attributeValue.attribute();
+    SettableDoubleGauge metric = _metricMap.get(key);
+    if (metric == null) {
+      metric = createMetric(attributeValue);
+      _metricMap.put(key, metric);
+    }
+    metric.setValue(attributeValue.value());
+  }
+
+  private SettableDoubleGauge createMetric(MbeanAttributeValue attributeValue) {
+    String signalFxMetricName = generateSignalFxMetricName(attributeValue.mbean(), attributeValue.attribute());
+    SettableDoubleGauge gauge = null;
+
+    if (signalFxMetricName.contains("partition")) {
+      String partitionNumber = "" + signalFxMetricName.charAt(signalFxMetricName.length() - 1);
+      signalFxMetricName = signalFxMetricName.substring(0,  signalFxMetricName.length() - 2);
+      gauge = _metricMetadata.forMetric(new SettableDoubleGauge())
+          .withMetricName(signalFxMetricName).metric();
+      _metricMetadata.forMetric(gauge).withDimension("partition", partitionNumber);
+    } else {
+      gauge = _metricMetadata.forMetric(new SettableDoubleGauge())
+          .withMetricName(signalFxMetricName).metric();
+    }
+    LOG.info("Creating metric : {}", signalFxMetricName);
+
+    for (Map.Entry<String, String> entry : _dimensionsMap.entrySet()) {
+      _metricMetadata.forMetric(gauge).withDimension(entry.getKey(), entry.getValue());
+    }
+    _metricMetadata.forMetric(gauge).register(_metricRegistry);
+
+    return gauge;
+  }
+}

--- a/src/main/java/com/linkedin/kmf/services/SignalFxMetricsReporterService.java
+++ b/src/main/java/com/linkedin/kmf/services/SignalFxMetricsReporterService.java
@@ -1,11 +1,5 @@
-/**
- * Copyright 2016 LinkedIn Corp. Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
- * file except in compliance with the License. You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/*
+ * Copyright (C) 2018 SignalFx, Inc. All rights reserved.
  */
 package com.linkedin.kmf.services;
 

--- a/src/main/java/com/linkedin/kmf/services/SignalFxMetricsReporterService.java
+++ b/src/main/java/com/linkedin/kmf/services/SignalFxMetricsReporterService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 SignalFx, Inc. All rights reserved.
+ * Copyright (C) 2018 SignalFx, Inc. Licensed under the Apache 2 License.
  */
 package com.linkedin.kmf.services;
 

--- a/src/main/java/com/linkedin/kmf/services/SignalFxMetricsReporterService.java
+++ b/src/main/java/com/linkedin/kmf/services/SignalFxMetricsReporterService.java
@@ -162,11 +162,7 @@ public class SignalFxMetricsReporterService implements Service {
     SettableDoubleGauge gauge = null;
 
     if (signalFxMetricName.contains("partition")) {
-      String partitionNumber = "" + signalFxMetricName.charAt(signalFxMetricName.length() - 1);
-      signalFxMetricName = signalFxMetricName.substring(0,  signalFxMetricName.length() - 2);
-      gauge = _metricMetadata.forMetric(new SettableDoubleGauge())
-          .withMetricName(signalFxMetricName).metric();
-      _metricMetadata.forMetric(gauge).withDimension("partition", partitionNumber);
+      gauge = createPartitionMetric(signalFxMetricName);
     } else {
       gauge = _metricMetadata.forMetric(new SettableDoubleGauge())
           .withMetricName(signalFxMetricName).metric();
@@ -180,4 +176,15 @@ public class SignalFxMetricsReporterService implements Service {
 
     return gauge;
   }
+
+  private SettableDoubleGauge createPartitionMetric(String signalFxMetricName) {
+    int divider = signalFxMetricName.lastIndexOf('-');
+    String partitionNumber = signalFxMetricName.substring(divider + 1);
+    signalFxMetricName = signalFxMetricName.substring(0,  divider);
+    SettableDoubleGauge gauge = _metricMetadata.forMetric(new SettableDoubleGauge())
+        .withMetricName(signalFxMetricName).metric();
+    _metricMetadata.forMetric(gauge).withDimension("partition", partitionNumber);
+    return gauge;
+  }
 }
+

--- a/src/main/java/com/linkedin/kmf/services/configs/SignalFxMetricsReporterServiceConfig.java
+++ b/src/main/java/com/linkedin/kmf/services/configs/SignalFxMetricsReporterServiceConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 SignalFx, Inc. All rights reserved.
+ * Copyright (C) 2018 SignalFx, Inc. Licensed under the Apache 2 License.
  */
 package com.linkedin.kmf.services.configs;
 

--- a/src/main/java/com/linkedin/kmf/services/configs/SignalFxMetricsReporterServiceConfig.java
+++ b/src/main/java/com/linkedin/kmf/services/configs/SignalFxMetricsReporterServiceConfig.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2016 LinkedIn Corp. Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.linkedin.kmf.services.configs;
+
+import java.util.Arrays;
+import java.util.Map;
+
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.config.ConfigDef;
+
+/**
+ * key/value pair used for configuring SignalFxMetricsReporterService
+ *
+ */
+public class SignalFxMetricsReporterServiceConfig extends AbstractConfig {
+  private static final ConfigDef CONFIG;
+
+  public static final String REPORT_METRICS_CONFIG = "report.metrics.list";
+  public static final String REPORT_METRICS_DOC = CommonServiceConfig.REPORT_METRICS_DOC;
+
+  public static final String REPORT_INTERVAL_SEC_CONFIG = CommonServiceConfig.REPORT_INTERVAL_SEC_CONFIG;
+  public static final String REPORT_INTERVAL_SEC_DOC = CommonServiceConfig.REPORT_INTERVAL_SEC_DOC;
+
+  public static final String REPORT_SIGNALFX_URL = "report.signalfx.url";
+  public static final String REPORT_SIGNALFX_URL_DOC = "The url of signalfx server which SignalFxMetricsReporterService will report the metrics values.";
+
+  public static final String SIGNALFX_METRIC_DIMENSION = "report.metric.dimensions";
+  public static final String SIGNALFX_METRIC_DIMENSION_DOC = "Dimensions added to each metric. Example: {\"key1:value1\", \"key2:value2\"} ";
+
+  public static final String SIGNALFX_TOKEN = "report.signalfx.token";
+  public static final String SIGNALFX_TOKEN_DOC = "SignalFx access token";
+
+  static {
+    CONFIG = new ConfigDef().define(REPORT_METRICS_CONFIG,
+                                    ConfigDef.Type.LIST,
+                                    Arrays.asList("kmf.services:*:*"),
+                                    ConfigDef.Importance.MEDIUM,
+                                    REPORT_METRICS_DOC)
+                             .define(REPORT_INTERVAL_SEC_CONFIG,
+                                    ConfigDef.Type.INT,
+                                    1,
+                                    ConfigDef.Importance.LOW,
+                                    REPORT_INTERVAL_SEC_DOC)
+                             .define(REPORT_SIGNALFX_URL,
+                                    ConfigDef.Type.STRING,
+                                    "",
+                                    ConfigDef.Importance.LOW,
+                                    REPORT_SIGNALFX_URL_DOC)
+                             .define(SIGNALFX_TOKEN,
+                                    ConfigDef.Type.STRING,
+                                    "",
+                                    ConfigDef.Importance.HIGH,
+                                    SIGNALFX_TOKEN_DOC);
+  }
+
+  public SignalFxMetricsReporterServiceConfig(Map<?, ?> props) {
+    super(CONFIG, props);
+  }
+}
+

--- a/src/main/java/com/linkedin/kmf/services/configs/SignalFxMetricsReporterServiceConfig.java
+++ b/src/main/java/com/linkedin/kmf/services/configs/SignalFxMetricsReporterServiceConfig.java
@@ -1,11 +1,5 @@
-/**
- * Copyright 2016 LinkedIn Corp. Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
- * file except in compliance with the License. You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/*
+ * Copyright (C) 2018 SignalFx, Inc. All rights reserved.
  */
 package com.linkedin.kmf.services.configs;
 


### PR DESCRIPTION
1. Adds a metrics reporting service to report the Kafka monitor metrics to SignalFx.
2. Suppress checkstyle of LinkedIn Corp. headers for SignalFx files
3. Add avg-delay metric per broker to determine latency for each broker from producer and consumer

SignalFx is monitoring platform that performs operational intelligence for data-driven DevOps