### PR TITLE
fix incorrected calculation of availability and separate PLE routing from rebalance

### DIFF
--- a/config/kafka-monitor.properties
+++ b/config/kafka-monitor.properties
@@ -51,6 +51,7 @@
     "topic-management.replicationFactor" : 1,
     "topic-management.partitionsToBrokersRatio" : 2.0,
     "topic-management.rebalance.interval.ms" : 600000,
+    "topic-management.preferred.leader.election.check.interval.ms" : 300000,
     "topic-management.topicFactory.props": {
     },
     "topic-management.topic.props": {

--- a/src/main/java/com/linkedin/kmf/services/MultiClusterTopicManagementService.java
+++ b/src/main/java/com/linkedin/kmf/services/MultiClusterTopicManagementService.java
@@ -348,7 +348,7 @@ public class MultiClusterTopicManagementService implements Service {
           ZK_CONNECTION_TIMEOUT_MS, Integer.MAX_VALUE, Time.SYSTEM, METRIC_GROUP_NAME, "SessionExpireListener");
 
       try {
-        if(!zkClient.reassignPartitionsInProgress()) {
+        if (!zkClient.reassignPartitionsInProgress()) {
           List<PartitionInfo> partitionInfoList = getPartitionInfo(zkClient, _topic);
           LOG.info(
               "MultiClusterTopicManagementService will trigger requested preferred leader election for the topic {} in cluster {}",

--- a/src/main/java/com/linkedin/kmf/services/configs/MultiClusterTopicManagementServiceConfig.java
+++ b/src/main/java/com/linkedin/kmf/services/configs/MultiClusterTopicManagementServiceConfig.java
@@ -29,6 +29,10 @@ public class MultiClusterTopicManagementServiceConfig extends AbstractConfig {
   public static final String REBALANCE_INTERVAL_MS_DOC = "The gap in ms between the times the cluster balance on the "
       + "monitor topic is checked.  Set this to a large value to disable automatic topic rebalance.";
 
+  public static final String PREFERRED_LEADER_ELECTION_CHECK_INTERVAL_MS_CONFIG = "topic-management.preferred.leader.election.check.interval.ms";
+  public static final String PREFERRED_LEADER_ELECTION_CHECK_INTERVAL_MS_DOC = "The gap in ms between the times to check if preferred leader election"
+      + " can be performed when requested during rebalance";
+
   static {
     CONFIG = new ConfigDef()
       .define(TOPIC_CONFIG,
@@ -40,7 +44,12 @@ public class MultiClusterTopicManagementServiceConfig extends AbstractConfig {
               1000 * 60 * 10,
               atLeast(10),
               ConfigDef.Importance.LOW,
-              REBALANCE_INTERVAL_MS_DOC);
+              REBALANCE_INTERVAL_MS_DOC)
+        .define(PREFERRED_LEADER_ELECTION_CHECK_INTERVAL_MS_CONFIG,
+            ConfigDef.Type.LONG,
+            1000 * 60 * 5,
+            atLeast(5),
+            ConfigDef.Importance.LOW, PREFERRED_LEADER_ELECTION_CHECK_INTERVAL_MS_DOC);
   }
 
   public MultiClusterTopicManagementServiceConfig(Map<?, ?> props) {


### PR DESCRIPTION
fix two issues:

1) Incorrectly availability for offline partition when setting  _treatZeroThroughputAsUnavailable to false and large producer timeout.

The sample history KMF keeps is 60 seconds, which means all samples expire after 60 seconds. If We have request timeout more than 60 seconds, there is some time window the reported availability will be 100% even some partitions are offline. 

2) preferred leader election is triggered while partition reassignment is still in progress.  This leads to potential issues a) the replica might be moved out of the selected PLE leader as a result of partition reassignment , and leads to multiple leadership movement. 2) the selected PLE leader might not be the preferred leader after reassignment. 
