### PR TITLE
allow brokers to be blacklisted when adding new partitions or reassigning partitions

### DIFF
--- a/src/main/java/com/linkedin/kmf/services/MultiClusterTopicManagementService.java
+++ b/src/main/java/com/linkedin/kmf/services/MultiClusterTopicManagementService.java
@@ -265,14 +265,34 @@ public class MultiClusterTopicManagementService implements Service {
         if (partitionNum < minPartitionNum) {
           LOG.info("MultiClusterTopicManagementService will increase partition of the topic {} "
               + "in cluster {} from {} to {}.", _topic, _zkConnect, partitionNum, minPartitionNum);
-
+          Collection<Integer> blackListedBrokers =
+              _topicFactory.getBlackListedBrokers(_zkConnect);
           scala.Option<scala.collection.Map<java.lang.Object, scala.collection.Seq<java.lang.Object>>> replicaAssignment = scala.Option.apply(null);
           scala.Option<Seq<Object>> brokerList = scala.Option.apply(null);
-          adminZkClient.addPartitions(_topic, existingAssignment, adminZkClient.getBrokerMetadatas(RackAwareMode.Disabled$.MODULE$, brokerList), minPartitionNum, replicaAssignment, false);
+          Collection<BrokerMetadata> brokers =
+              new HashSet<>(scala.collection.JavaConversions.asJavaCollection(adminZkClient.getBrokerMetadatas(RackAwareMode.Disabled$.MODULE$, brokerList)));
+
+          if (!blackListedBrokers.isEmpty()) {
+            brokers.removeIf(broker -> blackListedBrokers.contains(broker.id()));
+          }
+          adminZkClient.addPartitions(_topic, existingAssignment,
+              scala.collection.JavaConversions.collectionAsScalaIterable(brokers).toSeq(),
+              minPartitionNum, replicaAssignment, false);
         }
       } finally {
         zkClient.close();
       }
+    }
+
+    private Collection<Broker> getAvailableBrokers(KafkaZkClient zkClient) {
+      Collection<Broker> brokers =
+          new HashSet<>(scala.collection.JavaConversions.asJavaCollection(zkClient.getAllBrokersInCluster()));
+
+      Collection<Integer> blackListedBrokers =
+          _topicFactory.getBlackListedBrokers(_zkConnect);
+
+      brokers.removeIf(broker -> blackListedBrokers.contains(broker.id()));
+      return brokers;
     }
 
     void maybeReassignPartitionAndElectLeader() throws Exception {
@@ -281,7 +301,7 @@ public class MultiClusterTopicManagementService implements Service {
 
       try {
         List<PartitionInfo> partitionInfoList = getPartitionInfo(zkClient, _topic);
-        Collection<Broker> brokers = scala.collection.JavaConversions.asJavaCollection(zkClient.getAllBrokersInCluster());
+        Collection<Broker> brokers = getAvailableBrokers(zkClient);
         boolean partitionReassigned = false;
         if (partitionInfoList.size() == 0)
           throw new IllegalStateException("Topic " + _topic + " does not exist in cluster " + _zkConnect);

--- a/src/main/java/com/linkedin/kmf/services/MultiClusterTopicManagementService.java
+++ b/src/main/java/com/linkedin/kmf/services/MultiClusterTopicManagementService.java
@@ -265,11 +265,11 @@ public class MultiClusterTopicManagementService implements Service {
         if (partitionNum < minPartitionNum) {
           LOG.info("MultiClusterTopicManagementService will increase partition of the topic {} "
               + "in cluster {} from {} to {}.", _topic, _zkConnect, partitionNum, minPartitionNum);
-          Collection<Integer> blackListedBrokers =
+          Set<Integer> blackListedBrokers =
               _topicFactory.getBlackListedBrokers(_zkConnect);
           scala.Option<scala.collection.Map<java.lang.Object, scala.collection.Seq<java.lang.Object>>> replicaAssignment = scala.Option.apply(null);
           scala.Option<Seq<Object>> brokerList = scala.Option.apply(null);
-          Collection<BrokerMetadata> brokers =
+          Set<BrokerMetadata> brokers =
               new HashSet<>(scala.collection.JavaConversions.asJavaCollection(adminZkClient.getBrokerMetadatas(RackAwareMode.Disabled$.MODULE$, brokerList)));
 
           if (!blackListedBrokers.isEmpty()) {
@@ -284,11 +284,11 @@ public class MultiClusterTopicManagementService implements Service {
       }
     }
 
-    private Collection<Broker> getAvailableBrokers(KafkaZkClient zkClient) {
-      Collection<Broker> brokers =
+    private Set<Broker> getAvailableBrokers(KafkaZkClient zkClient) {
+      Set<Broker> brokers =
           new HashSet<>(scala.collection.JavaConversions.asJavaCollection(zkClient.getAllBrokersInCluster()));
 
-      Collection<Integer> blackListedBrokers =
+      Set<Integer> blackListedBrokers =
           _topicFactory.getBlackListedBrokers(_zkConnect);
 
       brokers.removeIf(broker -> blackListedBrokers.contains(broker.id()));

--- a/src/main/java/com/linkedin/kmf/topicfactory/DefaultTopicFactory.java
+++ b/src/main/java/com/linkedin/kmf/topicfactory/DefaultTopicFactory.java
@@ -11,10 +11,10 @@ package com.linkedin.kmf.topicfactory;
 
 import com.linkedin.kmf.common.Utils;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 
 
 public class DefaultTopicFactory implements TopicFactory {
@@ -29,7 +29,7 @@ public class DefaultTopicFactory implements TopicFactory {
   }
 
   @Override
-  public Collection<Integer> getBlackListedBrokers(String zkUrl) {
+  public Set<Integer> getBlackListedBrokers(String zkUrl) {
     return Collections.emptySet();
   }
 }

--- a/src/main/java/com/linkedin/kmf/topicfactory/DefaultTopicFactory.java
+++ b/src/main/java/com/linkedin/kmf/topicfactory/DefaultTopicFactory.java
@@ -11,6 +11,8 @@ package com.linkedin.kmf.topicfactory;
 
 import com.linkedin.kmf.common.Utils;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Properties;
 
@@ -24,5 +26,10 @@ public class DefaultTopicFactory implements TopicFactory {
   @Override
   public int createTopicIfNotExist(String zkUrl, String topic, int replicationFactor, double partitionToBrokerRatio, Properties topicConfig) {
     return Utils.createTopicIfNotExists(zkUrl, topic, replicationFactor, partitionToBrokerRatio, 1, topicConfig);
+  }
+
+  @Override
+  public Collection<Integer> getBlackListedBrokers(String zkUrl) {
+    return Collections.emptySet();
   }
 }

--- a/src/main/java/com/linkedin/kmf/topicfactory/TopicFactory.java
+++ b/src/main/java/com/linkedin/kmf/topicfactory/TopicFactory.java
@@ -9,11 +9,12 @@
  */
 package com.linkedin.kmf.topicfactory;
 
+import java.util.Collection;
 import java.util.Properties;
 
 
 /**
- * Constructs the monitor topic if it does not exist.
+ * Constructs the monitor topic if it does not exist, and provide blacklisted brokers info for topic management service
  *
  * Implementations of this class should have a public constructor with the following signature:
  *   Constructor(Map&lt;String, ?&gt; config) where config are additional configuration parameters passed in from the Kafka
@@ -33,5 +34,11 @@ public interface TopicFactory {
    */
 
   int createTopicIfNotExist(String zkUrl, String topic, int replicationFactor, double partitionToBrokerRatio, Properties topicProperties);
+
+  /**
+   * @param zkUrl zookeeper connection url
+   * @return A list of brokers that don't take new partitions or reassigned partitions for topics.
+   */
+  Collection<Integer> getBlackListedBrokers(String zkUrl);
 
 }

--- a/src/main/java/com/linkedin/kmf/topicfactory/TopicFactory.java
+++ b/src/main/java/com/linkedin/kmf/topicfactory/TopicFactory.java
@@ -9,8 +9,8 @@
  */
 package com.linkedin.kmf.topicfactory;
 
-import java.util.Collection;
 import java.util.Properties;
+import java.util.Set;
 
 
 /**
@@ -37,8 +37,8 @@ public interface TopicFactory {
 
   /**
    * @param zkUrl zookeeper connection url
-   * @return A list of brokers that don't take new partitions or reassigned partitions for topics.
+   * @return A set of brokers that don't take new partitions or reassigned partitions for topics.
    */
-  Collection<Integer> getBlackListedBrokers(String zkUrl);
+  Set<Integer> getBlackListedBrokers(String zkUrl);
 
 }


### PR DESCRIPTION

KMF today assign partitions or add new partitions to all kafka brokers in a cluster. However, there are use cases that we don't want KMF topic partitions to be created on certain brokers. For example, broker that is not in a healthy state and is being removed might not want to take any new KMF partitions.  This fix allows user to blacklist certain kafka brokers via topic factory so that blacklisted brokers will not be assigned new partitions or taking reassigned partitions. The default topic factory implementation doesn't blacklist any brokers. User can have custom implementation of topic factory where blacklisted broker info can be obtained dynamically.