### PR TITLE
Create a tarball/zip of all necessary files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,7 @@ buildscript {
 }
 apply plugin: 'maven-publish'
 apply plugin: 'com.jfrog.bintray'
+apply plugin: 'distribution'
 
 
 allprojects {
@@ -97,6 +98,8 @@ allprojects {
         artifact sourceJar
         artifact javadocJar
         artifact testJar
+        artifact distZip
+        artifact distTar
 
         pom {
           name = 'kafka-monitor'
@@ -129,6 +132,7 @@ allprojects {
   }
 
   task createConfigDocs( dependsOn : compileJava, type : JavaExec) {
+    outputs.dir configDocDir
     classpath sourceSets.main.runtimeClasspath
     main = 'com.linkedin.kmf.common.ConfigDocumentationGenerator'
     args = [configDocDir,
@@ -152,6 +156,39 @@ allprojects {
       exceptionFormat = 'full'
     }
   }
+
+  distributions {
+    main {
+      contents {
+        into('bin') {
+          from 'bin'
+        }
+        into('build/libs') {
+          from jar
+        }
+        into('build/dependant-libs') {
+          from copyDependantLibs
+        }
+        into('config') {
+          from 'config'
+        }
+        into('build/configDocs') {
+          from createConfigDocs
+        }
+        into('webapp') {
+          from 'webapp'
+        }
+        from('.') {
+          include 'README.md'
+        }
+      }
+    }
+  }
+  tasks.withType(Tar){
+    compression = Compression.GZIP
+    extension = 'tar.gz'
+  }
+
 }
 
 bintray {


### PR DESCRIPTION
Currently, to be able to use kafka-monitor, people need to clone the repo or download the automatic tarball/zip of the releases, then build with gradle, then launch kafka-monitor.
By building a distribution tarball/zip during the build with only the necessary content (no need of the `src` folder nor `build/classes`), the users can simply download this distribution package, unarchive it and use it directly.
Thoses distribution packages can be added as assets in the GitHub releases.

```shell
$ ./gradlew clean assembleDist
BUILD SUCCESSFUL in 4s
7 actionable tasks: 7 executed

$ ls -1 build/distributions/
kafka-monitor-2.0.8-SNAPSHOT.tar.gz
kafka-monitor-2.0.8-SNAPSHOT.zip

$ tar tvzf build/distributions/kafka-monitor-2.0.8-SNAPSHOT.tar.gz 
drwxr-xr-x 0/0               0 2019-12-12 10:28 kafka-monitor-2.0.8-SNAPSHOT/
drwxr-xr-x 0/0               0 2019-12-12 10:28 kafka-monitor-2.0.8-SNAPSHOT/bin/
-rwxr-xr-x 0/0             579 2019-12-12 09:33 kafka-monitor-2.0.8-SNAPSHOT/bin/end-to-end-test.sh
-rwxr-xr-x 0/0            3103 2019-12-12 09:33 kafka-monitor-2.0.8-SNAPSHOT/bin/kmf-run-class.sh
-rwxr-xr-x 0/0             568 2019-12-12 09:33 kafka-monitor-2.0.8-SNAPSHOT/bin/kafka-monitor-start.sh
-rwxr-xr-x 0/0             581 2019-12-12 09:33 kafka-monitor-2.0.8-SNAPSHOT/bin/single-cluster-monitor.sh
drwxr-xr-x 0/0               0 2019-12-12 09:33 kafka-monitor-2.0.8-SNAPSHOT/bin/windows/
-rw-r--r-- 0/0             756 2019-12-12 09:33 kafka-monitor-2.0.8-SNAPSHOT/bin/windows/kafka-monitor-start.bat
-rw-r--r-- 0/0            4714 2019-12-12 09:33 kafka-monitor-2.0.8-SNAPSHOT/bin/windows/kmf-run-class.bat
drwxr-xr-x 0/0               0 2019-12-12 10:28 kafka-monitor-2.0.8-SNAPSHOT/build/
drwxr-xr-x 0/0               0 2019-12-12 10:28 kafka-monitor-2.0.8-SNAPSHOT/build/libs/
-rw-r--r-- 0/0          112506 2019-12-12 10:28 kafka-monitor-2.0.8-SNAPSHOT/build/libs/kafka-monitor-2.0.8-SNAPSHOT.jar
drwxr-xr-x 0/0               0 2019-12-12 10:28 kafka-monitor-2.0.8-SNAPSHOT/build/dependant-libs/
-rw-r--r-- 0/0           34654 2019-12-12 10:28 kafka-monitor-2.0.8-SNAPSHOT/build/dependant-libs/paranamer-2.8.jar
-rw-r--r-- 0/0           19936 2019-12-12 10:28 kafka-monitor-2.0.8-SNAPSHOT/build/dependant-libs/jsr305-3.0.2.jar
-rw-r--r-- 0/0         3980208 2019-12-12 10:28 kafka-monitor-2.0.8-SNAPSHOT/build/dependant-libs/zstd-jni-1.4.0-1.jar
-rw-r--r-- 0/0          136567 2019-12-12 10:28 kafka-monitor-2.0.8-SNAPSHOT/build/dependant-libs/metrics-core-3.2.3.jar
-rw-r--r-- 0/0           67897 2019-12-12 10:28 kafka-monitor-2.0.8-SNAPSHOT/build/dependant-libs/jackson-annotations-2.10.0.jar
-rw-r--r-- 0/0          489884 2019-12-12 10:28 kafka-monitor-2.0.8-SNAPSHOT/build/dependant-libs/log4j-1.2.17.jar
-rw-r--r-- 0/0           78146 2019-12-12 10:28 kafka-monitor-2.0.8-SNAPSHOT/build/dependant-libs/jopt-simple-5.0.4.jar
-rw-r--r-- 0/0            5420 2019-12-12 10:28 kafka-monitor-2.0.8-SNAPSHOT/build/dependant-libs/paranamer-ant-2.2.jar
-rw-r--r-- 0/0          421339 2019-12-12 10:28 kafka-monitor-2.0.8-SNAPSHOT/build/dependant-libs/velocity-1.6.4.jar
-rw-r--r-- 0/0         3645095 2019-12-12 10:28 kafka-monitor-2.0.8-SNAPSHOT/build/dependant-libs/scala-reflect-2.12.8.jar
-rw-r--r-- 0/0          288218 2019-12-12 10:28 kafka-monitor-2.0.8-SNAPSHOT/build/dependant-libs/jetty-util-8.1.19.v20160209.jar
-rw-r--r-- 0/0          360317 2019-12-12 10:28 kafka-monitor-2.0.8-SNAPSHOT/build/dependant-libs/jetty-server-8.1.19.v20160209.jar
-rw-r--r-- 0/0            6931 2019-12-12 10:28 kafka-monitor-2.0.8-SNAPSHOT/build/dependant-libs/paranamer-generator-2.2.jar
-rw-r--r-- 0/0         2740491 2019-12-12 10:28 kafka-monitor-2.0.8-SNAPSHOT/build/dependant-libs/kafka-clients-2.3.1.jar
-rw-r--r-- 0/0          386509 2019-12-12 10:28 kafka-monitor-2.0.8-SNAPSHOT/build/dependant-libs/jackson-mapper-asl-1.4.2.jar
-rw-r--r-- 0/0          106036 2019-12-12 10:28 kafka-monitor-2.0.8-SNAPSHOT/build/dependant-libs/jetty-io-8.1.19.v20160209.jar
-rw-r--r-- 0/0          281694 2019-12-12 10:28 kafka-monitor-2.0.8-SNAPSHOT/build/dependant-libs/bsh-2.0b4.jar
-rw-r--r-- 0/0           34395 2019-12-12 10:28 kafka-monitor-2.0.8-SNAPSHOT/build/dependant-libs/jackson-datatype-jdk8-2.10.0.jar
-rw-r--r-- 0/0           10874 2019-12-12 10:28 kafka-monitor-2.0.8-SNAPSHOT/build/dependant-libs/graphite-client-1.1.0-RELEASE.jar
-rw-r--r-- 0/0           82123 2019-12-12 10:28 kafka-monitor-2.0.8-SNAPSHOT/build/dependant-libs/metrics-core-2.2.0.jar
-rw-r--r-- 0/0          784316 2019-12-12 10:28 kafka-monitor-2.0.8-SNAPSHOT/build/dependant-libs/netty-3.2.1.Final.jar
-rw-r--r-- 0/0           21163 2019-12-12 10:28 kafka-monitor-2.0.8-SNAPSHOT/build/dependant-libs/jetty-continuation-8.1.19.v20160209.jar
-rw-r--r-- 0/0           74626 2019-12-12 10:28 kafka-monitor-2.0.8-SNAPSHOT/build/dependant-libs/zkclient-0.11.jar
-rw-r--r-- 0/0           15121 2019-12-12 10:28 kafka-monitor-2.0.8-SNAPSHOT/build/dependant-libs/spotbugs-annotations-3.1.9.jar
-rw-r--r-- 0/0          134133 2019-12-12 10:28 kafka-monitor-2.0.8-SNAPSHOT/build/dependant-libs/servlet-api-2.5-20081211.jar
-rw-r--r-- 0/0          575389 2019-12-12 10:28 kafka-monitor-2.0.8-SNAPSHOT/build/dependant-libs/commons-collections-3.2.1.jar
-rw-r--r-- 0/0            8869 2019-12-12 10:28 kafka-monitor-2.0.8-SNAPSHOT/build/dependant-libs/slf4j-log4j12-1.7.6.jar
-rw-r--r-- 0/0          173236 2019-12-12 10:28 kafka-monitor-2.0.8-SNAPSHOT/build/dependant-libs/qdox-1.10.1.jar
-rw-r--r-- 0/0         4175009 2019-12-12 10:28 kafka-monitor-2.0.8-SNAPSHOT/build/dependant-libs/kafka_2.12-2.3.1.jar
-rw-r--r-- 0/0           99793 2019-12-12 10:28 kafka-monitor-2.0.8-SNAPSHOT/build/dependant-libs/jackson-dataformat-csv-2.10.0.jar
-rw-r--r-- 0/0          911603 2019-12-12 10:28 kafka-monitor-2.0.8-SNAPSHOT/build/dependant-libs/zookeeper-3.4.14.jar
-rw-r--r-- 0/0         5276900 2019-12-12 10:28 kafka-monitor-2.0.8-SNAPSHOT/build/dependant-libs/scala-library-2.12.10.jar
-rw-r--r-- 0/0           43740 2019-12-12 10:28 kafka-monitor-2.0.8-SNAPSHOT/build/dependant-libs/jackson-module-paranamer-2.10.0.jar
-rw-r--r-- 0/0           23931 2019-12-12 10:28 kafka-monitor-2.0.8-SNAPSHOT/build/dependant-libs/json-simple-1.1.1.jar
-rw-r--r-- 0/0          341862 2019-12-12 10:28 kafka-monitor-2.0.8-SNAPSHOT/build/dependant-libs/jackson-module-scala_2.12-2.10.0.jar
-rw-r--r-- 0/0          836479 2019-12-12 10:28 kafka-monitor-2.0.8-SNAPSHOT/build/dependant-libs/testng-6.8.8.jar
-rw-r--r-- 0/0           85269 2019-12-12 10:28 kafka-monitor-2.0.8-SNAPSHOT/build/dependant-libs/jolokia-jvm-1.3.3.jar
-rw-r--r-- 0/0           96382 2019-12-12 10:28 kafka-monitor-2.0.8-SNAPSHOT/build/dependant-libs/jetty-http-8.1.19.v20160209.jar
-rw-r--r-- 0/0         1323005 2019-12-12 10:28 kafka-monitor-2.0.8-SNAPSHOT/build/dependant-libs/ant-1.7.1.jar
-rw-r--r-- 0/0          348635 2019-12-12 10:28 kafka-monitor-2.0.8-SNAPSHOT/build/dependant-libs/jackson-core-2.10.0.jar
-rw-r--r-- 0/0           43398 2019-12-12 10:28 kafka-monitor-2.0.8-SNAPSHOT/build/dependant-libs/asm-3.2.jar
-rw-r--r-- 0/0          639985 2019-12-12 10:28 kafka-monitor-2.0.8-SNAPSHOT/build/dependant-libs/lz4-java-1.6.0.jar
-rw-r--r-- 0/0          326745 2019-12-12 10:28 kafka-monitor-2.0.8-SNAPSHOT/build/dependant-libs/jolokia-core-1.3.3.jar
-rw-r--r-- 0/0           64952 2019-12-12 10:28 kafka-monitor-2.0.8-SNAPSHOT/build/dependant-libs/json-20140107.jar
-rw-r--r-- 0/0           54709 2019-12-12 10:28 kafka-monitor-2.0.8-SNAPSHOT/build/dependant-libs/scala-logging_2.12-3.9.0.jar
-rw-r--r-- 0/0            8978 2019-12-12 10:28 kafka-monitor-2.0.8-SNAPSHOT/build/dependant-libs/java-statsd-client-3.0.1.jar
-rw-r--r-- 0/0          279193 2019-12-12 10:28 kafka-monitor-2.0.8-SNAPSHOT/build/dependant-libs/commons-lang-2.5.jar
-rw-r--r-- 0/0         1400944 2019-12-12 10:28 kafka-monitor-2.0.8-SNAPSHOT/build/dependant-libs/jackson-databind-2.10.0.jar
-rw-r--r-- 0/0           65261 2019-12-12 10:28 kafka-monitor-2.0.8-SNAPSHOT/build/dependant-libs/oro-2.0.8.jar
-rw-r--r-- 0/0         7994952 2019-12-12 10:28 kafka-monitor-2.0.8-SNAPSHOT/build/dependant-libs/signalfx-codahale-0.0.47.jar
-rw-r--r-- 0/0          568780 2019-12-12 10:28 kafka-monitor-2.0.8-SNAPSHOT/build/dependant-libs/avro-1.4.0.jar
-rw-r--r-- 0/0          536866 2019-12-12 10:28 kafka-monitor-2.0.8-SNAPSHOT/build/dependant-libs/jetty-6.1.22.jar
-rw-r--r-- 0/0          200387 2019-12-12 10:28 kafka-monitor-2.0.8-SNAPSHOT/build/dependant-libs/javax.servlet-3.0.0.v201112011016.jar
-rw-r--r-- 0/0          150970 2019-12-12 10:28 kafka-monitor-2.0.8-SNAPSHOT/build/dependant-libs/jackson-core-asl-1.4.2.jar
-rw-r--r-- 0/0           55585 2019-12-12 10:28 kafka-monitor-2.0.8-SNAPSHOT/build/dependant-libs/jcommander-1.27.jar
-rw-r--r-- 0/0           20437 2019-12-12 10:28 kafka-monitor-2.0.8-SNAPSHOT/build/dependant-libs/audience-annotations-0.5.0.jar
-rw-r--r-- 0/0           12143 2019-12-12 10:28 kafka-monitor-2.0.8-SNAPSHOT/build/dependant-libs/ant-launcher-1.7.1.jar
-rw-r--r-- 0/0          176973 2019-12-12 10:28 kafka-monitor-2.0.8-SNAPSHOT/build/dependant-libs/jetty-util-6.1.22.jar
-rw-r--r-- 0/0         2021167 2019-12-12 10:28 kafka-monitor-2.0.8-SNAPSHOT/build/dependant-libs/snappy-java-1.1.7.3.jar
-rw-r--r-- 0/0           83818 2019-12-12 10:28 kafka-monitor-2.0.8-SNAPSHOT/build/dependant-libs/argparse4j-0.5.0.jar
-rw-r--r-- 0/0           41139 2019-12-12 10:28 kafka-monitor-2.0.8-SNAPSHOT/build/dependant-libs/slf4j-api-1.7.26.jar
drwxr-xr-x 0/0               0 2019-12-12 10:28 kafka-monitor-2.0.8-SNAPSHOT/config/
-rw-r--r-- 0/0            5714 2019-12-12 09:35 kafka-monitor-2.0.8-SNAPSHOT/config/kafka-monitor.properties
-rw-r--r-- 0/0            3850 2019-12-12 09:35 kafka-monitor-2.0.8-SNAPSHOT/config/multi-cluster-monitor.properties
-rw-r--r-- 0/0            1339 2019-12-12 09:33 kafka-monitor-2.0.8-SNAPSHOT/config/log4j.properties
-rw-r--r-- 0/0             183 2019-12-12 09:33 kafka-monitor-2.0.8-SNAPSHOT/config/prometheus-exporter.yaml
drwxr-xr-x 0/0               0 2019-12-12 10:28 kafka-monitor-2.0.8-SNAPSHOT/build/configDocs/
-rw-r--r-- 0/0             459 2019-12-12 10:28 kafka-monitor-2.0.8-SNAPSHOT/build/configDocs/MultiClusterMonitorConfig.html
-rw-r--r-- 0/0            4128 2019-12-12 10:28 kafka-monitor-2.0.8-SNAPSHOT/build/configDocs/ProduceServiceConfig.html
-rw-r--r-- 0/0            2585 2019-12-12 10:28 kafka-monitor-2.0.8-SNAPSHOT/build/configDocs/ConsumeServiceConfig.html
-rw-r--r-- 0/0            2638 2019-12-12 10:28 kafka-monitor-2.0.8-SNAPSHOT/build/configDocs/TopicManagementServiceConfig.html
-rw-r--r-- 0/0            1053 2019-12-12 10:28 kafka-monitor-2.0.8-SNAPSHOT/build/configDocs/DefaultMetricsReporterServiceConfig.html
-rw-r--r-- 0/0             462 2019-12-12 10:28 kafka-monitor-2.0.8-SNAPSHOT/build/configDocs/JettyServiceConfig.html
drwxr-xr-x 0/0               0 2019-12-12 10:28 kafka-monitor-2.0.8-SNAPSHOT/webapp/
drwxr-xr-x 0/0               0 2019-12-12 09:33 kafka-monitor-2.0.8-SNAPSHOT/webapp/js/
-rw-r--r-- 0/0          118177 2019-12-12 09:33 kafka-monitor-2.0.8-SNAPSHOT/webapp/js/Chart.js
-rw-r--r-- 0/0           18423 2019-12-12 09:33 kafka-monitor-2.0.8-SNAPSHOT/webapp/js/json2.js
-rw-r--r-- 0/0            9282 2019-12-12 09:33 kafka-monitor-2.0.8-SNAPSHOT/webapp/js/jolokia-min.js
-rw-r--r-- 0/0           33178 2019-12-12 09:33 kafka-monitor-2.0.8-SNAPSHOT/webapp/js/jolokia.js
-rw-r--r-- 0/0            2638 2019-12-12 09:33 kafka-monitor-2.0.8-SNAPSHOT/webapp/js/jolokia-simple-min.js
-rw-r--r-- 0/0            7347 2019-12-12 09:33 kafka-monitor-2.0.8-SNAPSHOT/webapp/index.html
-rw-r--r-- 0/0            6640 2019-12-12 09:35 kafka-monitor-2.0.8-SNAPSHOT/README.md
```