### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ monitor topic. This allows Kafka Monitor to detect performance issue on every
 broker without requiring users to manually manage the partition assignment of
 the monitor topic.
 
+Kafka Monitor is used in conjunction with different middle-layer services such as linkedin-kafka-clients and Kafka REST proxy in order to monitor single clusters, pipeline desination clusters, as well as Kafka REST clusters, as done at Linkedin engineering for real-time cluster healthchecks.
+
 ## Getting Started
 
 ### Prerequisites


### PR DESCRIPTION
Kafka Monitor is used in conjunction with different middle-layer services such as linkedin-kafka-clients and Kafka REST proxy in order to monitor single clusters, pipeline desination clusters, as well as Kafka REST.