### PR TITLE
JsonFromGenericRecord Method in Utils class Enable public access

### DIFF
--- a/src/main/java/com/linkedin/kmf/common/Utils.java
+++ b/src/main/java/com/linkedin/kmf/common/Utils.java
@@ -150,7 +150,7 @@ public class Utils {
     return record;
   }
 
-  private static String jsonFromGenericRecord(GenericRecord record) {
+  public static String jsonFromGenericRecord(GenericRecord record) {
     ByteArrayOutputStream out = new ByteArrayOutputStream();
     GenericDatumWriter<GenericRecord> writer = new GenericDatumWriter<>(DefaultTopicSchema.MESSAGE_V0);
 


### PR DESCRIPTION
** jsonFromGenericRecord(..)** in `Utils` class enable `public` access such that external `dependencies` can have access to this method when needed.