### PR TITLE
Fix for instantiating ConsumeService

### DIFF
--- a/src/main/java/com/linkedin/kmf/KafkaMonitor.java
+++ b/src/main/java/com/linkedin/kmf/KafkaMonitor.java
@@ -11,6 +11,7 @@ package com.linkedin.kmf;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linkedin.kmf.apps.App;
+import com.linkedin.kmf.services.ConsumerFactory;
 import com.linkedin.kmf.services.ConsumerFactoryImpl;
 import com.linkedin.kmf.services.Service;
 import java.io.BufferedReader;
@@ -76,7 +77,7 @@ public class KafkaMonitor {
           completableFuture.complete(null);
           ConsumerFactoryImpl consumerFactory = new ConsumerFactoryImpl(props);
           Service service = (Service) Class.forName(className)
-              .getConstructor(String.class, CompletableFuture.class, ConsumerFactoryImpl.class)
+              .getConstructor(String.class, CompletableFuture.class, ConsumerFactory.class)
               .newInstance(name, completableFuture, consumerFactory);
           _services.put(name, service);
         } else {


### PR DESCRIPTION
This fixes https://github.com/linkedin/kafka-monitor/issues/195

The latest PR https://github.com/linkedin/kafka-monitor/pull/196 didn't fix the issue:

I was testing this and I got:
```
Exception in thread "main" java.lang.NoSuchMethodException: com.linkedin.kmf.services.ConsumeService.<init>(java.lang.String, java.util.concurrent.CompletableFuture, com.linkedin.kmf.services.ConsumerFactoryImpl)
        at java.lang.Class.getConstructor0(Class.java:3082)
        at java.lang.Class.getConstructor(Class.java:1825)
        at com.linkedin.kmf.KafkaMonitor.<init>(KafkaMonitor.java:79)
        at com.linkedin.kmf.KafkaMonitor.main(KafkaMonitor.java:187)

```

Then I cloned this repo, and modified the `kafka-monitor.properties` file, uncommented:
```json
# Example consume-service to consume messages
   "consume-service": {
       "class.name": "com.linkedin.kmf.services.ConsumeService",
       "topic": "kafka-monitor-topic",
       "zookeeper.connect": "localhost:2181",
       "bootstrap.servers": "localhost:9092",
       "consume.latency.sla.ms": "20000",
       "consume.consumer.props": {
       }
   }
```

and run: `./bin/kafka-monitor-start.sh config/kafka-monitor.properties` and after a few seconds I got the same issue:
```
2020-02-18 17:16:58 WARN  ConsumerConfig:355 - The configuration 'consume.consumer.props' was supplied but isn't a known config.
2020-02-18 17:16:58 WARN  ConsumerConfig:355 - The configuration 'zookeeper.connect' was supplied but isn't a known config.
2020-02-18 17:16:58 WARN  ConsumerConfig:355 - The configuration 'topic' was supplied but isn't a known config.
2020-02-18 17:16:58 WARN  ConsumerConfig:355 - The configuration 'consume.latency.sla.ms' was supplied but isn't a known config.
2020-02-18 17:16:58 WARN  ConsumerConfig:355 - The configuration 'class.name' was supplied but isn't a known config.
2020-02-18 17:16:58 INFO  AppInfoParser:117 - Kafka version: 2.3.1
2020-02-18 17:16:58 INFO  AppInfoParser:118 - Kafka commitId: 18a913733fb71c01
2020-02-18 17:16:58 INFO  AppInfoParser:119 - Kafka startTimeMs: 1582064218107

2020-02-18 17:16:58 INFO  KafkaConsumer:964 - [Consumer clientId=kmf-consumer, groupId=kmf-consumer-group-1007965611] Subscribed to topic(s): kafka-monitor-topic
Exception in thread "main" java.lang.NoSuchMethodException: com.linkedin.kmf.services.ConsumeService.<init>(java.lang.String, java.util.concurrent.CompletableFuture, com.linkedin.kmf.services.ConsumerFactoryImpl)
        at java.lang.Class.getConstructor0(Class.java:3082)
        at java.lang.Class.getConstructor(Class.java:1825)
        at com.linkedin.kmf.KafkaMonitor.<init>(KafkaMonitor.java:79)
        at com.linkedin.kmf.KafkaMonitor.main(KafkaMonitor.java:187)
```

The problem was on the modified line, as the type of the parameter is
`ConsumerFactory.class` not `ConsumerFactoryImpl.class`