### PR TITLE
Correct naming for report metric: offline-runnable-count

### DIFF
--- a/config/kafka-monitor.properties
+++ b/config/kafka-monitor.properties
@@ -82,7 +82,7 @@
     "class.name": "com.linkedin.kmf.services.DefaultMetricsReporterService",
     "report.interval.sec": 1,
     "report.metrics.list": [
-        "kmf:type=kafka-monitor,name=*:offline-runnable-count",
+        "kmf:type=kafka-monitor:offline-runnable-count",
         "kmf.services:type=produce-service,name=*:produce-availability-avg",
         "kmf.services:type=consume-service,name=*:consume-availability-avg",
         "kmf.services:type=commit-availability-service,name=*:offsets-committed-avg",


### PR DESCRIPTION
When the application is run, the logs aren't printing out the offline runnable count, and it's due to the wrongly configured report metric name for `"kmf:type=kafka-monitor,name=*:offline-runnable-count",`

Tested with ` "kmf:type=kafka-monitor:offline-runnable-count",` -> and the metric is correctly logged.
Signed-off-by: Andrew Choi <andchoi@linkedin.com>