### PR TITLE
Simplifications of CompletableFuture + Ensuring MultiClusterTopicManagementService performs the topic partitions operations first.

### DIFF
--- a/src/main/java/com/linkedin/kmf/KafkaMonitor.java
+++ b/src/main/java/com/linkedin/kmf/KafkaMonitor.java
@@ -106,7 +106,7 @@ public class KafkaMonitor {
     return false;
   }
 
-  public synchronized void start() {
+  public synchronized void start() throws Exception {
     if (!_isRunning.compareAndSet(false, true)) {
       return;
     }

--- a/src/main/java/com/linkedin/kmf/apps/App.java
+++ b/src/main/java/com/linkedin/kmf/apps/App.java
@@ -12,7 +12,7 @@ package com.linkedin.kmf.apps;
 
 public interface App {
 
-  void start();
+  void start() throws Exception;
 
   void stop();
 

--- a/src/main/java/com/linkedin/kmf/apps/MultiClusterMonitor.java
+++ b/src/main/java/com/linkedin/kmf/apps/MultiClusterMonitor.java
@@ -76,8 +76,8 @@ public class MultiClusterMonitor implements App {
   @Override
   public void start() {
     _multiClusterTopicManagementService.start();
-    CompletableFuture<Void> topicManagementReady = _multiClusterTopicManagementService.topicManagementResult();
-    topicManagementReady.thenRun(() -> {
+    CompletableFuture<Void> topicPartitionResult = _multiClusterTopicManagementService.topicPartitionResult();
+    topicPartitionResult.thenRun(() -> {
       _produceService.start();
       _consumeService.start();
     });

--- a/src/main/java/com/linkedin/kmf/apps/SingleClusterMonitor.java
+++ b/src/main/java/com/linkedin/kmf/apps/SingleClusterMonitor.java
@@ -11,6 +11,7 @@
 package com.linkedin.kmf.apps;
 
 import com.linkedin.kmf.services.ConsumeService;
+import com.linkedin.kmf.services.ConsumerFactory;
 import com.linkedin.kmf.services.ConsumerFactoryImpl;
 import com.linkedin.kmf.services.DefaultMetricsReporterService;
 import com.linkedin.kmf.services.JettyService;
@@ -29,6 +30,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import net.sourceforge.argparse4j.ArgumentParsers;
 import net.sourceforge.argparse4j.inf.ArgumentParser;
 import net.sourceforge.argparse4j.inf.Namespace;
@@ -48,6 +50,7 @@ import org.slf4j.LoggerFactory;
 public class SingleClusterMonitor implements App {
   private static final Logger LOG = LoggerFactory.getLogger(SingleClusterMonitor.class);
 
+  private static final int SERVICES_INITIAL_CAPACITY = 4;
   private final TopicManagementService _topicManagementService;
   private final ProduceService _produceService;
   private final ConsumeService _consumeService;
@@ -55,14 +58,13 @@ public class SingleClusterMonitor implements App {
   private final List<Service> _allServices;
 
   public SingleClusterMonitor(Map<String, Object> props, String name) throws Exception {
+    ConsumerFactory consumerFactory = new ConsumerFactoryImpl(props);
     _name = name;
     _topicManagementService = new TopicManagementService(props, name);
-    CompletableFuture<Void> topicPartitionReady = _topicManagementService.topicPartitionResult();
+    CompletableFuture<Void> topicPartitionResult = _topicManagementService.topicPartitionResult();
     _produceService = new ProduceService(props, name);
-    ConsumerFactoryImpl consumerFactory = new ConsumerFactoryImpl(props);
-    _consumeService = new ConsumeService(name, topicPartitionReady, consumerFactory);
-    int servicesInitialCapacity = 4;
-    _allServices = new ArrayList<>(servicesInitialCapacity);
+    _consumeService = new ConsumeService(name, topicPartitionResult, consumerFactory);
+    _allServices = new ArrayList<>(SERVICES_INITIAL_CAPACITY);
     _allServices.add(_topicManagementService);
     _allServices.add(_produceService);
     _allServices.add(_consumeService);
@@ -71,11 +73,26 @@ public class SingleClusterMonitor implements App {
   @Override
   public void start() {
     _topicManagementService.start();
-    CompletableFuture<Void> completableFuture = _topicManagementService.topicManagementResult();
-    completableFuture.thenRun(() -> {
+    CompletableFuture<Void> topicPartitionResult = _topicManagementService.topicPartitionResult();
+    try {
+      /* Delay 2 second to reduce the chance that produce and consumer thread has race condition
+      with TopicManagementService and MultiClusterTopicManagementService */
+      long threadSleepMs = 1000 * 2;
+      Thread.sleep(threadSleepMs);
+    } catch (InterruptedException e) {
+      LOG.error("InterruptedException while thread sleeping.", e);
+    }
+    CompletableFuture<Void> topicPartitionFuture = topicPartitionResult.thenRun(() -> {
       _produceService.start();
       _consumeService.start();
     });
+
+    try {
+      topicPartitionFuture.get();
+    } catch (InterruptedException | ExecutionException e) {
+      LOG.error("Exception occurred while getting the TopicPartitionFuture", e);
+    }
+
     LOG.info(_name + "/SingleClusterMonitor started.");
   }
 

--- a/src/main/java/com/linkedin/kmf/services/ConsumerFactoryImpl.java
+++ b/src/main/java/com/linkedin/kmf/services/ConsumerFactoryImpl.java
@@ -18,10 +18,13 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Random;
+import java.util.concurrent.ExecutionException;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.serialization.StringDeserializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 public class ConsumerFactoryImpl implements ConsumerFactory {
@@ -34,9 +37,16 @@ public class ConsumerFactoryImpl implements ConsumerFactory {
       new String[] {ConsumeServiceConfig.BOOTSTRAP_SERVERS_CONFIG, ConsumeServiceConfig.ZOOKEEPER_CONNECT_CONFIG};
   private int _latencySlaMs;
   private static AdminClient adminClient;
+  private static final Logger LOGGER = LoggerFactory.getLogger(ConsumerFactoryImpl.class);
 
   public ConsumerFactoryImpl(Map<String, Object> props) throws Exception {
+    LOGGER.info("Creating AdminClient.");
     adminClient = AdminClient.create(props);
+    try {
+      LOGGER.info("TESTING ConsumerFactoryImpl adminClient: {}", adminClient.describeCluster().clusterId().get().toLowerCase());
+    } catch (InterruptedException | ExecutionException e) {
+      LOGGER.error("Exception occurred while describing cluster", e);
+    }
     Map consumerPropsOverride = props.containsKey(ConsumeServiceConfig.CONSUMER_PROPS_CONFIG)
         ? (Map) props.get(ConsumeServiceConfig.CONSUMER_PROPS_CONFIG) : new HashMap<>();
     ConsumeServiceConfig config = new ConsumeServiceConfig(props);

--- a/src/main/java/com/linkedin/kmf/services/ConsumerFactoryImpl.java
+++ b/src/main/java/com/linkedin/kmf/services/ConsumerFactoryImpl.java
@@ -18,7 +18,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Random;
-import java.util.concurrent.ExecutionException;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.config.ConfigException;
@@ -37,16 +36,11 @@ public class ConsumerFactoryImpl implements ConsumerFactory {
       new String[] {ConsumeServiceConfig.BOOTSTRAP_SERVERS_CONFIG, ConsumeServiceConfig.ZOOKEEPER_CONNECT_CONFIG};
   private int _latencySlaMs;
   private static AdminClient adminClient;
-  private static final Logger LOGGER = LoggerFactory.getLogger(ConsumerFactoryImpl.class);
+  private static final Logger LOG = LoggerFactory.getLogger(ConsumerFactoryImpl.class);
 
   public ConsumerFactoryImpl(Map<String, Object> props) throws Exception {
-    LOGGER.info("Creating AdminClient.");
+    LOG.info("Creating AdminClient.");
     adminClient = AdminClient.create(props);
-    try {
-      LOGGER.info("TESTING ConsumerFactoryImpl adminClient: {}", adminClient.describeCluster().clusterId().get().toLowerCase());
-    } catch (InterruptedException | ExecutionException e) {
-      LOGGER.error("Exception occurred while describing cluster", e);
-    }
     Map consumerPropsOverride = props.containsKey(ConsumeServiceConfig.CONSUMER_PROPS_CONFIG)
         ? (Map) props.get(ConsumeServiceConfig.CONSUMER_PROPS_CONFIG) : new HashMap<>();
     ConsumeServiceConfig config = new ConsumeServiceConfig(props);

--- a/src/main/java/com/linkedin/kmf/services/MultiClusterTopicManagementService.java
+++ b/src/main/java/com/linkedin/kmf/services/MultiClusterTopicManagementService.java
@@ -80,8 +80,6 @@ public class MultiClusterTopicManagementService implements Service {
   private final long _preferredLeaderElectionIntervalMs;
   private final ScheduledExecutorService _executor;
 
-  private final CompletableFuture<Void> _topicManagementResult;
-
 
   @SuppressWarnings("unchecked")
   public MultiClusterTopicManagementService(Map<String, Object> props, String serviceName) throws Exception {
@@ -93,14 +91,9 @@ public class MultiClusterTopicManagementService implements Service {
     _topicManagementByCluster = initializeTopicManagementHelper(propsByCluster, topic);
     _scheduleIntervalMs = config.getInt(MultiClusterTopicManagementServiceConfig.REBALANCE_INTERVAL_MS_CONFIG);
     _preferredLeaderElectionIntervalMs = config.getLong(MultiClusterTopicManagementServiceConfig.PREFERRED_LEADER_ELECTION_CHECK_INTERVAL_MS_CONFIG);
-    _topicManagementResult = new CompletableFuture<>();
     _executor = Executors.newSingleThreadScheduledExecutor(
       r -> new Thread(r, _serviceName + "-multi-cluster-topic-management-service"));
     _topicPartitionResult.complete(null);
-  }
-
-  public CompletableFuture<Void> topicManagementResult() {
-    return _topicManagementResult;
   }
 
   public CompletableFuture<Void> topicPartitionResult() {
@@ -182,7 +175,7 @@ public class MultiClusterTopicManagementService implements Service {
         for (TopicManagementHelper helper : _topicManagementByCluster.values()) {
           helper.maybeAddPartitions(minPartitionNum);
         }
-        _topicManagementResult.complete(null);
+
         for (Map.Entry<String, TopicManagementHelper> entry : _topicManagementByCluster.entrySet()) {
           String clusterName = entry.getKey();
           TopicManagementHelper helper = entry.getValue();

--- a/src/main/java/com/linkedin/kmf/services/MultiClusterTopicManagementService.java
+++ b/src/main/java/com/linkedin/kmf/services/MultiClusterTopicManagementService.java
@@ -28,7 +28,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import kafka.admin.AdminUtils;
@@ -92,12 +91,8 @@ public class MultiClusterTopicManagementService implements Service {
     _topicManagementByCluster = initializeTopicManagementHelper(propsByCluster, topic);
     _scheduleIntervalMs = config.getInt(MultiClusterTopicManagementServiceConfig.REBALANCE_INTERVAL_MS_CONFIG);
     _preferredLeaderElectionIntervalMs = config.getLong(MultiClusterTopicManagementServiceConfig.PREFERRED_LEADER_ELECTION_CHECK_INTERVAL_MS_CONFIG);
-    _executor = Executors.newSingleThreadScheduledExecutor(new ThreadFactory() {
-      @Override
-      public Thread newThread(Runnable r) {
-        return new Thread(r, _serviceName + "-multi-cluster-topic-management-service");
-      }
-    });
+    _executor = Executors.newSingleThreadScheduledExecutor(
+        r -> new Thread(r, _serviceName + "-multi-cluster-topic-management-service"));
     _topicPartitionResult.complete(null);
   }
 

--- a/src/main/java/com/linkedin/kmf/services/MultiClusterTopicManagementService.java
+++ b/src/main/java/com/linkedin/kmf/services/MultiClusterTopicManagementService.java
@@ -28,6 +28,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import kafka.admin.AdminUtils;
@@ -91,8 +92,12 @@ public class MultiClusterTopicManagementService implements Service {
     _topicManagementByCluster = initializeTopicManagementHelper(propsByCluster, topic);
     _scheduleIntervalMs = config.getInt(MultiClusterTopicManagementServiceConfig.REBALANCE_INTERVAL_MS_CONFIG);
     _preferredLeaderElectionIntervalMs = config.getLong(MultiClusterTopicManagementServiceConfig.PREFERRED_LEADER_ELECTION_CHECK_INTERVAL_MS_CONFIG);
-    _executor = Executors.newSingleThreadScheduledExecutor(
-      r -> new Thread(r, _serviceName + "-multi-cluster-topic-management-service"));
+    _executor = Executors.newSingleThreadScheduledExecutor(new ThreadFactory() {
+      @Override
+      public Thread newThread(Runnable r) {
+        return new Thread(r, _serviceName + "-multi-cluster-topic-management-service");
+      }
+    });
     _topicPartitionResult.complete(null);
   }
 

--- a/src/main/java/com/linkedin/kmf/services/MultiClusterTopicManagementService.java
+++ b/src/main/java/com/linkedin/kmf/services/MultiClusterTopicManagementService.java
@@ -92,7 +92,7 @@ public class MultiClusterTopicManagementService implements Service {
     _scheduleIntervalMs = config.getInt(MultiClusterTopicManagementServiceConfig.REBALANCE_INTERVAL_MS_CONFIG);
     _preferredLeaderElectionIntervalMs = config.getLong(MultiClusterTopicManagementServiceConfig.PREFERRED_LEADER_ELECTION_CHECK_INTERVAL_MS_CONFIG);
     _executor = Executors.newSingleThreadScheduledExecutor(
-        r -> new Thread(r, _serviceName + "-multi-cluster-topic-management-service"));
+      r -> new Thread(r, _serviceName + "-multi-cluster-topic-management-service"));
     _topicPartitionResult.complete(null);
   }
 

--- a/src/main/java/com/linkedin/kmf/services/TopicManagementService.java
+++ b/src/main/java/com/linkedin/kmf/services/TopicManagementService.java
@@ -23,16 +23,14 @@ import java.util.concurrent.CompletableFuture;
  */
 public class TopicManagementService implements Service {
   private final MultiClusterTopicManagementService _multiClusterTopicManagementService;
-  CompletableFuture<Void> _topicPartitionResult = new CompletableFuture<>();
 
   public TopicManagementService(Map<String, Object> props, String serviceName) throws Exception {
     Map<String, Object> serviceProps = createMultiClusterTopicManagementServiceProps(props, serviceName);
     _multiClusterTopicManagementService = new MultiClusterTopicManagementService(serviceProps, serviceName);
-    _topicPartitionResult.complete(null);
   }
 
   public CompletableFuture<Void> topicPartitionResult() {
-    return _topicPartitionResult;
+    return _multiClusterTopicManagementService.topicPartitionResult();
   }
 
   /**
@@ -67,10 +65,6 @@ public class TopicManagementService implements Service {
   @Override
   public synchronized void start() {
     _multiClusterTopicManagementService.start();
-  }
-
-  public CompletableFuture<Void> topicManagementResult() {
-    return _multiClusterTopicManagementService.topicManagementResult();
   }
 
 

--- a/src/main/java/com/linkedin/kmf/tests/BasicEndToEndTest.java
+++ b/src/main/java/com/linkedin/kmf/tests/BasicEndToEndTest.java
@@ -55,8 +55,8 @@ public class BasicEndToEndTest implements Test {
   @Override
   public void start() {
     _topicManagementService.start();
-    CompletableFuture<Void> completableFuture = _topicManagementService.topicManagementResult();
-    completableFuture.thenRun(() -> {
+    CompletableFuture<Void> topicPartitionResult = _topicManagementService.topicPartitionResult();
+    topicPartitionResult.thenRun(() -> {
       try {
         _produceService.start();
         _consumeService.start();

--- a/src/test/java/com/linkedin/kmf/services/ConsumeServiceTest.java
+++ b/src/test/java/com/linkedin/kmf/services/ConsumeServiceTest.java
@@ -61,7 +61,7 @@ public class ConsumeServiceTest {
     Assert.assertFalse(consumeService.isRunning());
 
     /* Should start */
-    consumeService.start();
+    consumeService.testStart();
     Assert.assertTrue(consumeService.isRunning());
 
     /* Should allow start to be called more than once */
@@ -87,7 +87,7 @@ public class ConsumeServiceTest {
     Assert.assertEquals(metrics.metrics().get(metrics.metricName("offsets-committed-total", METRIC_GROUP_NAME, tags)).metricValue(), 0.0);
 
     /* Should start */
-    consumeService.start();
+    consumeService.testStart();
     Assert.assertTrue(consumeService.isRunning());
 
     /* in milliseconds */
@@ -173,7 +173,7 @@ public class ConsumeServiceTest {
     };
 
     thread.start();
-    consumeService.start();
+    consumeService.testStart();
     Thread.sleep(100);
 
     consumeService.stop();


### PR DESCRIPTION
This removes the cases where the Xinfra Monitor fails to locate the topic partitions for a topic. 
1 - Removal of Race Condition between `MultiClusterTopicManagementService` and `ProduceService/ConsumeService`
2 - Thread.sleep to ensure the `MultiClusterTopicManagementService` executes the operation of preparing topics (and creation of it if necessary), followed by the topic partitions.
3 - move the `topic-partitions-count` to `start()` ConsumeService such that the topic and partitions preparation is fully executed first by the `MultiClusterTopicManagementService` and `TopicManagementService` -> see (*1)
4 - Simplify the usage of  `CompletableFuture<Void>` by using only one of  `CompletableFuture<Void>` instead of two  `CompletableFuture<Void>`


(*1)
``` Sensor topicPartitionCount = metrics.sensor("topic-partitions");
      DescribeTopicsResult describeTopicsResult = _adminClient.describeTopics(Collections.singleton(_topic));
      Map<String, KafkaFuture<TopicDescription>> topicResultValues = describeTopicsResult.values();
      KafkaFuture<TopicDescription> topicDescriptionKafkaFuture = topicResultValues.get(_topic);
      TopicDescription topicDescription = null;
      try {
        topicDescription = topicDescriptionKafkaFuture.get();
      } catch (InterruptedException | ExecutionException e) {
        LOG.error("Exception occurred while getting the topicDescriptionKafkaFuture", e);
      }
      int partitionCount = topicDescription.partitions().size();
      topicPartitionCount.add(
          new MetricName("topic-partitions-count", METRIC_GROUP_NAME, "The total number of partitions for the topic.", tags),
          new CumulativeSum(partitionCount));```

Sample log output:

```2020-02-20 20:17:15 INFO  MultiClusterTopicManagementService:126 - single-cluster-monitor/MultiClusterTopicManagementService started.
2020-02-20 20:17:15 INFO  MultiClusterTopicManagementService:274 - CreateTopicsResult: {kafka-monitor-topic-z49=KafkaFuture{value=null,exception=null,done=false}}.
2020-02-20 20:17:15 INFO  Log4jControllerRegistration$:31 - Registered kafka:type=kafka.Log4jController MBean
2020-02-20 20:17:15 INFO  Metadata:261 - [Producer clientId=kmf-client-id] Cluster ID: 4mUaHr6GRk2B9NGkEwrxzg
```

```2020-02-20 20:17:20 INFO  DefaultMetricsReporterService:86 - ==============================================================
kmf:type=kafka-monitor:offline-runnable-count=0.0
kmf.services:name=single-cluster-monitor,type=produce-service:produce-availability-avg=1.0
kmf.services:name=single-cluster-monitor,type=consume-service:consume-availability-avg=1.0
kmf.services:name=single-cluster-monitor,type=commit-availability-service:offsets-committed-avg=1.0
kmf.services:name=single-cluster-monitor,type=commit-availability-service:failed-commit-offsets-avg=0.0
kmf.services:name=single-cluster-monitor,type=produce-service:records-produced-total=56.0
kmf.services:name=single-cluster-monitor,type=consume-service:records-consumed-total=38.0
kmf.services:name=single-cluster-monitor,type=consume-service:records-lost-total=0.0
kmf.services:name=single-cluster-monitor,type=consume-service:records-lost-rate=0.0
kmf.services:name=single-cluster-monitor,type=consume-service:records-duplicated-total=0.0
kmf.services:name=single-cluster-monitor,type=consume-service:records-delay-ms-avg=4.157894736842105
kmf.services:name=single-cluster-monitor,type=produce-service:records-produced-rate=0.9349070936075727
kmf.services:name=single-cluster-monitor,type=produce-service:produce-error-rate=0.0
kmf.services:name=single-cluster-monitor,type=consume-service:consume-error-rate=0.0
kmf.services:name=single-cluster-monitor,type=commit-availability-service:offsets-committed-total=1.0
kmf.services:name=single-cluster-monitor,type=commit-availability-service:failed-commit-offsets-total=0.0```