### PR TITLE
Fix log4j2 conf to use kafka-client.log file

### DIFF
--- a/config/log4j2.properties
+++ b/config/log4j2.properties
@@ -7,35 +7,40 @@
 # an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 status = error
+dest = err
 name = PropertiesConfig
 
-filters = threshold
 filter.threshold.type = ThresholdFilter
 filter.threshold.level = debug
-
-additivity.com.linkedin.kmf.core.KafkaMonitor = false
-additivity.org.apache.kafka = false
-additivity.kafka = false
-
-appenders = console
 
 appender.console.type = Console
 appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
+appender.console.layout.pattern = [%d] %p %m (%c)%n
 
-appender.stdout=org.apache.log4j.ConsoleAppender
-appender.stdout.layout=org.apache.log4j.PatternLayout
-appender.stdout.layout.ConversionPattern=[%d] %p %m (%c)%n
+appender.kafka.type = RollingFile
+appender.kafka.name = KAFKA
+appender.kafka.filename = ${sys:kafka.logs.dir}/kafka-client.log
+appender.kafka.filePattern = ${sys:kafka.logs.dir}/kafka-client.log.%d{yyyy-MM-dd-HH}
+appender.kafka.layout.type = PatternLayout
+appender.kafka.layout.pattern = [%d] %p %m (%c)%n
+appender.kafka.policies.type = Policies
+appender.kafka.policies.time.type = TimeBasedTriggeringPolicy
 
-appender.kafkaClientAppender=org.apache.log4j.DailyRollingFileAppender
-appender.kafkaClientAppender.DatePattern='.'yyyy-MM-dd-HH
-appender.kafkaClientAppender.File=${kafka.logs.dir}/kafka-client.log
-appender.kafkaClientAppender.layout=org.apache.log4j.PatternLayout
-appender.kafkaClientAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
-
-rootLogger = INFO
 rootLogger.level = info
-rootLogger.appenderRefs = stdout
-rootLogger.appenderRef.stdout.ref = STDOUT
+rootLogger.appenderRef.console.ref = STDOUT
 
+logger.kmf.name = com.linkedin.kmf.core.KafkaMonitor
+logger.kmf.level = info
+logger.kmf.additivity = false
+logger.kmf.appenderRef.console.ref = STDOUT
+
+logger.kafkaClient.name = org.apache.kafka
+logger.kafkaClient.level = warn
+logger.kafkaClient.additivity = false
+logger.kafkaClient.appenderRef.kafka.ref = KAFKA
+
+logger.kafka.name = kafka
+logger.kafka.level = warn
+logger.kafka.additivity = false
+logger.kafka.appenderRef.kafka.ref = KAFKA


### PR DESCRIPTION
- Remove misconfigured 'stdout' appender
- Fix 'kafkaClientAppender' appender
- Fix use of system properties
- Add configuration to use 'kafkaClientAppender' for kafka logs