### PR TITLE
SingleClusterMonitor - Add More kmf.services metrics for commit-availability-service (failed commits)

### DIFF
--- a/src/main/java/com/linkedin/kmf/apps/SingleClusterMonitor.java
+++ b/src/main/java/com/linkedin/kmf/apps/SingleClusterMonitor.java
@@ -332,7 +332,10 @@ public class SingleClusterMonitor implements App {
       "kmf.services:type=produce-service,name=*:records-produced-rate",
       "kmf.services:type=produce-service,name=*:produce-error-rate",
       "kmf.services:type=consume-service,name=*:consume-error-rate",
+      "kmf.services:type=commit-availability-service,name=*:offsets-committed-total",
       "kmf.services:type=commit-availability-service,name=*:offsets-committed-avg",
+      "kmf.services:type=commit-availability-service,name=*:failed-commit-offsets-total",
+      "kmf.services:type=commit-availability-service,name=*:failed-commit-offsets-avg",
       "kmf.services:type=commit-availability-service,name=*:commit-latency-avg"
     );
     props.put(DefaultMetricsReporterServiceConfig.REPORT_METRICS_CONFIG, metrics);


### PR DESCRIPTION
SingleClusterMonitor - Add More kmf.services metrics for commit-availability-service (failed commits)
```
  "kmf.services:type=commit-availability-service,name=*:offsets-committed-total",
  "kmf.services:type=commit-availability-service,name=*:failed-commit-offsets-total",
  "kmf.services:type=commit-availability-service,name=*:failed-commit-offsets-avg",
```

Signed-off-by: Andrew Choi <li_andchoi@microsoft.com>