### PR TITLE
Metrics Export Service Config and Properties to include Commit-latency-service -> commit-offset-latency-ms-avg

### DIFF
--- a/config/kafka-monitor.properties
+++ b/config/kafka-monitor.properties
@@ -81,8 +81,6 @@
         "kmf.services:type=produce-service,name=*:produce-availability-avg",
         "kmf.services:type=consume-service,name=*:consume-availability-avg",
         "kmf.services:type=commit-availability-service,name=*:offsets-committed-avg",
-        "kmf.services:type=commit-availability-service,name=*:commit-latency-avg",
-        "kmf.services:type=commit-availability-service,name=*:commit-availability-avg",
         "kmf.services:type=commit-availability-service,name=*:failed-commit-offsets-avg",
         "kmf.services:type=produce-service,name=*:records-produced-total",
         "kmf.services:type=consume-service,name=*:records-consumed-total",
@@ -94,6 +92,11 @@
         "kmf.services:type=produce-service,name=*:produce-error-rate",
         "kmf.services:type=consume-service,name=*:consume-error-rate",
         "kmf.services:type=commit-availability-service,name=*:offsets-committed-total",
+        "kmf.services:type=commit-latency-service,name=*:commit-offset-latency-ms-avg",
+        "kmf.services:type=commit-latency-service,name=*:commit-offset-latency-ms-max",
+        "kmf.services:type=commit-latency-service,name=*:commit-offset-latency-ms-99th",
+        "kmf.services:type=commit-latency-service,name=*:commit-offset-latency-ms-999th",
+        "kmf.services:type=commit-latency-service,name=*:commit-offset-latency-ms-9999th",
         "kmf.services:type=commit-availability-service,name=*:failed-commit-offsets-total"
     ]
   }

--- a/src/main/java/com/linkedin/kmf/apps/SingleClusterMonitor.java
+++ b/src/main/java/com/linkedin/kmf/apps/SingleClusterMonitor.java
@@ -336,7 +336,11 @@ public class SingleClusterMonitor implements App {
       "kmf.services:type=commit-availability-service,name=*:offsets-committed-avg",
       "kmf.services:type=commit-availability-service,name=*:failed-commit-offsets-total",
       "kmf.services:type=commit-availability-service,name=*:failed-commit-offsets-avg",
-      "kmf.services:type=commit-availability-service,name=*:commit-latency-avg"
+      "kmf.services:type=commit-latency-service,name=*:commit-offset-latency-ms-avg",
+      "kmf.services:type=commit-latency-service,name=*:commit-offset-latency-ms-max",
+      "kmf.services:type=commit-latency-service,name=*:commit-offset-latency-ms-99th",
+      "kmf.services:type=commit-latency-service,name=*:commit-offset-latency-ms-999th",
+      "kmf.services:type=commit-latency-service,name=*:commit-offset-latency-ms-9999th"
     );
     props.put(DefaultMetricsReporterServiceConfig.REPORT_METRICS_CONFIG, metrics);
 


### PR DESCRIPTION
**Append:**
      "kmf.services:type=commit-latency-service,name=*:commit-offset-latency-ms-avg",
      "kmf.services:type=commit-latency-service,name=*:commit-offset-latency-ms-max",
      "kmf.services:type=commit-latency-service,name=*:commit-offset-latency-ms-99th",
      "kmf.services:type=commit-latency-service,name=*:commit-offset-latency-ms-999th",
      "kmf.services:type=commit-latency-service,name=*:commit-offset-latency-ms-9999th"
--> for consumer offset commit latency metrics.

**Remove:**
  "kmf.services:type=commit-availability-service,name=*:commit-latency-avg",	
  "kmf.services:type=commit-availability-service,name=*:commit-availability-avg",
--> `commit-latency-avg"` and `commit-availability-avg` are outdated names which is renamed to `commit-offset-latency-ms-avg`. 


Signed-off-by: Andrew Choi <li_andchoi@microsoft.com>