### PR TITLE
Performance Improvements with Collection.singletonList

### DIFF
--- a/src/main/java/com/linkedin/kmf/services/ConsumeMetrics.java
+++ b/src/main/java/com/linkedin/kmf/services/ConsumeMetrics.java
@@ -77,7 +77,7 @@ public class ConsumeMetrics {
 
     metrics.addMetric(new MetricName("consume-availability-avg", METRIC_GROUP_NAME, "The average consume availability", tags),
       (config, now) -> {
-        double recordsConsumedRate = metrics.metrics().get(metrics.metricName("records-consumed-rate", METRIC_GROUP_NAME, tags)).value();
+        double recordsConsumedRate = (double) metrics.metrics().get(metrics.metricName("records-consumed-rate", METRIC_GROUP_NAME, tags)).metricValue();
         double recordsLostRate = metrics.metrics().get(metrics.metricName("records-lost-rate", METRIC_GROUP_NAME, tags)).value();
         double recordsDelayedRate = metrics.metrics().get(metrics.metricName("records-delayed-rate", METRIC_GROUP_NAME, tags)).value();
 

--- a/src/main/java/com/linkedin/kmf/services/MultiClusterTopicManagementService.java
+++ b/src/main/java/com/linkedin/kmf/services/MultiClusterTopicManagementService.java
@@ -314,8 +314,7 @@ public class MultiClusterTopicManagementService implements Service {
     }
 
     private Set<Node> getAvailableBrokers() throws ExecutionException, InterruptedException {
-      Set<Node> brokers = new HashSet<>();
-      brokers.addAll(_adminClient.describeCluster().nodes().get());
+      Set<Node> brokers = new HashSet<>(_adminClient.describeCluster().nodes().get());
       Set<Integer> blackListedBrokers = _topicFactory.getBlackListedBrokers(_zkConnect);
       brokers.removeIf(broker -> blackListedBrokers.contains(broker.id()));
       return brokers;

--- a/src/main/java/com/linkedin/kmf/services/ProduceService.java
+++ b/src/main/java/com/linkedin/kmf/services/ProduceService.java
@@ -57,7 +57,7 @@ import org.slf4j.LoggerFactory;
 public class ProduceService implements Service {
   private static final Logger LOG = LoggerFactory.getLogger(ProduceService.class);
   private static final String METRIC_GROUP_NAME = "produce-service";
-  private static final String[] NONOVERRIDABLE_PROPERTIES = new String[]{
+  private static final String[] NON_OVERRIDABLE_PROPERTIES = new String[]{
     ProduceServiceConfig.BOOTSTRAP_SERVERS_CONFIG,
     ProduceServiceConfig.ZOOKEEPER_CONNECT_CONFIG
   };
@@ -108,7 +108,7 @@ public class ProduceService implements Service {
     _producerPropsOverride = props.containsKey(ProduceServiceConfig.PRODUCER_PROPS_CONFIG)
       ? (Map) props.get(ProduceServiceConfig.PRODUCER_PROPS_CONFIG) : new HashMap<>();
 
-    for (String property: NONOVERRIDABLE_PROPERTIES) {
+    for (String property: NON_OVERRIDABLE_PROPERTIES) {
       if (_producerPropsOverride.containsKey(property)) {
         throw new ConfigException("Override must not contain " + property + " config.");
       }

--- a/src/main/java/com/linkedin/kmf/services/configs/DefaultMetricsReporterServiceConfig.java
+++ b/src/main/java/com/linkedin/kmf/services/configs/DefaultMetricsReporterServiceConfig.java
@@ -10,10 +10,10 @@
 
 package com.linkedin.kmf.services.configs;
 
+import java.util.Collections;
+import java.util.Map;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
-import java.util.Arrays;
-import java.util.Map;
 
 public class DefaultMetricsReporterServiceConfig extends AbstractConfig {
 
@@ -27,8 +27,7 @@ public class DefaultMetricsReporterServiceConfig extends AbstractConfig {
 
   static {
     CONFIG = new ConfigDef().define(REPORT_METRICS_CONFIG,
-                                    ConfigDef.Type.LIST,
-                                    Arrays.asList("kmf.services:*:*"),
+                                    ConfigDef.Type.LIST, Collections.singletonList("kmf.services:*:*"),
                                     ConfigDef.Importance.MEDIUM,
                                     REPORT_METRICS_DOC)
                             .define(REPORT_INTERVAL_SEC_CONFIG,

--- a/src/main/java/com/linkedin/kmf/services/configs/GraphiteMetricsReporterServiceConfig.java
+++ b/src/main/java/com/linkedin/kmf/services/configs/GraphiteMetricsReporterServiceConfig.java
@@ -11,11 +11,9 @@
 package com.linkedin.kmf.services.configs;
 
 import java.util.Collections;
+import java.util.Map;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
-
-import java.util.Arrays;
-import java.util.Map;
 
 public class GraphiteMetricsReporterServiceConfig extends AbstractConfig {
   private static final ConfigDef CONFIG;

--- a/src/main/java/com/linkedin/kmf/services/configs/GraphiteMetricsReporterServiceConfig.java
+++ b/src/main/java/com/linkedin/kmf/services/configs/GraphiteMetricsReporterServiceConfig.java
@@ -10,6 +10,7 @@
 
 package com.linkedin.kmf.services.configs;
 
+import java.util.Collections;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
 
@@ -36,8 +37,7 @@ public class GraphiteMetricsReporterServiceConfig extends AbstractConfig {
 
   static {
     CONFIG = new ConfigDef().define(REPORT_METRICS_CONFIG,
-                                    ConfigDef.Type.LIST,
-                                    Arrays.asList("kmf.services:*:*"),
+                                    ConfigDef.Type.LIST, Collections.singletonList("kmf.services:*:*"),
                                     ConfigDef.Importance.MEDIUM,
                                     REPORT_METRICS_DOC)
                             .define(REPORT_INTERVAL_SEC_CONFIG,

--- a/src/main/java/com/linkedin/kmf/services/configs/KafkaMetricsReporterServiceConfig.java
+++ b/src/main/java/com/linkedin/kmf/services/configs/KafkaMetricsReporterServiceConfig.java
@@ -10,6 +10,7 @@
 
 package com.linkedin.kmf.services.configs;
 
+import java.util.Collections;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
 
@@ -43,8 +44,7 @@ public class KafkaMetricsReporterServiceConfig extends AbstractConfig {
 
   static {
     CONFIG = new ConfigDef().define(REPORT_METRICS_CONFIG,
-                                    ConfigDef.Type.LIST,
-                                    Arrays.asList("kmf.services:*:*"),
+                                    ConfigDef.Type.LIST, Collections.singletonList("kmf.services:*:*"),
                                     ConfigDef.Importance.MEDIUM,
                                     REPORT_METRICS_DOC)
                             .define(REPORT_INTERVAL_SEC_CONFIG,

--- a/src/main/java/com/linkedin/kmf/services/configs/KafkaMetricsReporterServiceConfig.java
+++ b/src/main/java/com/linkedin/kmf/services/configs/KafkaMetricsReporterServiceConfig.java
@@ -11,11 +11,9 @@
 package com.linkedin.kmf.services.configs;
 
 import java.util.Collections;
+import java.util.Map;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
-
-import java.util.Arrays;
-import java.util.Map;
 
 import static org.apache.kafka.common.config.ConfigDef.Range.atLeast;
 

--- a/src/main/java/com/linkedin/kmf/services/configs/SignalFxMetricsReporterServiceConfig.java
+++ b/src/main/java/com/linkedin/kmf/services/configs/SignalFxMetricsReporterServiceConfig.java
@@ -4,10 +4,8 @@
 
 package com.linkedin.kmf.services.configs;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
-
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
 

--- a/src/main/java/com/linkedin/kmf/services/configs/SignalFxMetricsReporterServiceConfig.java
+++ b/src/main/java/com/linkedin/kmf/services/configs/SignalFxMetricsReporterServiceConfig.java
@@ -5,6 +5,7 @@
 package com.linkedin.kmf.services.configs;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Map;
 
 import org.apache.kafka.common.config.AbstractConfig;
@@ -34,8 +35,7 @@ public class SignalFxMetricsReporterServiceConfig extends AbstractConfig {
 
   static {
     CONFIG = new ConfigDef().define(REPORT_METRICS_CONFIG,
-                                    ConfigDef.Type.LIST,
-                                    Arrays.asList("kmf.services:*:*"),
+                                    ConfigDef.Type.LIST, Collections.singletonList("kmf.services:*:*"),
                                     ConfigDef.Importance.MEDIUM,
                                     REPORT_METRICS_DOC)
                              .define(REPORT_INTERVAL_SEC_CONFIG,

--- a/src/main/java/com/linkedin/kmf/services/configs/StatsdMetricsReporterServiceConfig.java
+++ b/src/main/java/com/linkedin/kmf/services/configs/StatsdMetricsReporterServiceConfig.java
@@ -14,6 +14,7 @@
 
 package com.linkedin.kmf.services.configs;
 
+import java.util.Collections;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
 
@@ -40,8 +41,7 @@ public class StatsdMetricsReporterServiceConfig extends AbstractConfig {
 
   static {
     CONFIG = new ConfigDef().define(REPORT_METRICS_CONFIG,
-                                    ConfigDef.Type.LIST,
-                                    Arrays.asList("kmf.services:*:*"),
+                                    ConfigDef.Type.LIST, Collections.singletonList("kmf.services:*:*"),
                                     ConfigDef.Importance.MEDIUM,
                                     REPORT_METRICS_DOC)
                             .define(REPORT_INTERVAL_SEC_CONFIG,

--- a/src/main/java/com/linkedin/kmf/services/configs/StatsdMetricsReporterServiceConfig.java
+++ b/src/main/java/com/linkedin/kmf/services/configs/StatsdMetricsReporterServiceConfig.java
@@ -15,11 +15,9 @@
 package com.linkedin.kmf.services.configs;
 
 import java.util.Collections;
+import java.util.Map;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
-
-import java.util.Arrays;
-import java.util.Map;
 
 public class StatsdMetricsReporterServiceConfig extends AbstractConfig {
   private static final ConfigDef CONFIG;


### PR DESCRIPTION
Performance Improvements with Collection.singletonList

1 - use `Collections.singletonList("kmf.services:*:*")`list for performance improvements
2 - Redundant assignments removal.
3 - Use MetricValue casted to double. 

Signed-off-by: Andrew Choi <li_andchoi@microsoft.com>