### PR TITLE
MetricValue casted to double to avoid deprecated APIs.

### DIFF
--- a/src/main/java/com/linkedin/kmf/services/ConsumeMetrics.java
+++ b/src/main/java/com/linkedin/kmf/services/ConsumeMetrics.java
@@ -77,8 +77,8 @@ public class ConsumeMetrics {
 
     metrics.addMetric(new MetricName("consume-availability-avg", METRIC_GROUP_NAME, "The average consume availability", tags),
       (config, now) -> {
-        double recordsConsumedRate = metrics.metrics().get(metrics.metricName("records-consumed-rate", METRIC_GROUP_NAME, tags)).value();
-        double recordsLostRate = metrics.metrics().get(metrics.metricName("records-lost-rate", METRIC_GROUP_NAME, tags)).value();
+        double recordsConsumedRate = (double) metrics.metrics().get(metrics.metricName("records-consumed-rate", METRIC_GROUP_NAME, tags)).metricValue();
+        double recordsLostRate = (double) metrics.metrics().get(metrics.metricName("records-lost-rate", METRIC_GROUP_NAME, tags)).metricValue();
         double recordsDelayedRate = (double) metrics.metrics().get(metrics.metricName("records-delayed-rate", METRIC_GROUP_NAME, tags)).metricValue();
 
         if (new Double(recordsLostRate).isNaN())

--- a/src/main/java/com/linkedin/kmf/services/ConsumeMetrics.java
+++ b/src/main/java/com/linkedin/kmf/services/ConsumeMetrics.java
@@ -79,7 +79,7 @@ public class ConsumeMetrics {
       (config, now) -> {
         double recordsConsumedRate = metrics.metrics().get(metrics.metricName("records-consumed-rate", METRIC_GROUP_NAME, tags)).value();
         double recordsLostRate = metrics.metrics().get(metrics.metricName("records-lost-rate", METRIC_GROUP_NAME, tags)).value();
-        double recordsDelayedRate = metrics.metrics().get(metrics.metricName("records-delayed-rate", METRIC_GROUP_NAME, tags)).value();
+        double recordsDelayedRate = (double) metrics.metrics().get(metrics.metricName("records-delayed-rate", METRIC_GROUP_NAME, tags)).metricValue();
 
         if (new Double(recordsLostRate).isNaN())
           recordsLostRate = 0;


### PR DESCRIPTION
MetricValue casted to double to avoid deprecated APIs.

```        double recordsDelayedRate = (double) metrics.metrics().get(metrics.metricName("records-delayed-rate", METRIC_GROUP_NAME, tags)).metricValue();```

Signed-off-by: Andrew Choi <li_andchoi@microsoft.com>