### PR TITLE
PreferredLeaderElections (PLE) Kafka Clients 2.4.0

### DIFF
--- a/src/main/java/com/linkedin/kmf/services/MultiClusterTopicManagementService.java
+++ b/src/main/java/com/linkedin/kmf/services/MultiClusterTopicManagementService.java
@@ -420,9 +420,9 @@ public class MultiClusterTopicManagementService implements Service {
       }
 
       ElectLeadersOptions newOptions = new ElectLeadersOptions();
-      newOptions.timeoutMs(new ElectLeadersOptions().timeoutMs());
+      ElectionType electionType = ElectionType.PREFERRED;
       Set<TopicPartition> topicPartitions = new HashSet<>(partitions);
-      ElectLeadersResult electLeadersResult = _adminClient.electLeaders(ElectionType.PREFERRED, topicPartitions, newOptions);
+      ElectLeadersResult electLeadersResult = _adminClient.electLeaders(electionType, topicPartitions, newOptions);
 
       LOG.info("{}: triggerPreferredLeaderElection - {}", this.getClass().toString(), electLeadersResult.all().get());
     }


### PR DESCRIPTION
`_adminClient.electPreferredLeaders`(...) is deprecated. 
Update the class method to use the new API for PreferredLeaderElections (PLE) in Kafka Clients 2.4.0.
