### PR TITLE
Fix NoSuchFieldError DEFAULT_SSL_PRINCIPAL_MAPPING_RULES

### DIFF
--- a/src/main/java/com/linkedin/kmf/common/Utils.java
+++ b/src/main/java/com/linkedin/kmf/common/Utils.java
@@ -95,8 +95,8 @@ public class Utils {
         NewTopic newTopic = new NewTopic(topic, partitionCount, replicationFactor);
         //noinspection rawtypes
         newTopic.configs((Map) topicConfig);
-        @SuppressWarnings("rawtypes")
-        List topics = new ArrayList<NewTopic>();
+
+        List<NewTopic> topics = new ArrayList<>();
         topics.add(newTopic);
         adminClient.createTopics(topics);
       } catch (TopicExistsException e) {

--- a/src/main/java/com/linkedin/kmf/common/Utils.java
+++ b/src/main/java/com/linkedin/kmf/common/Utils.java
@@ -31,7 +31,6 @@ import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.io.Encoder;
 import org.apache.avro.io.JsonEncoder;
 import org.apache.kafka.clients.admin.AdminClient;
-import org.apache.kafka.clients.admin.CreateTopicsResult;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.common.errors.TopicExistsException;
 import org.json.JSONObject;
@@ -99,8 +98,7 @@ public class Utils {
         @SuppressWarnings("rawtypes")
         List topics = new ArrayList<NewTopic>();
         topics.add(newTopic);
-        CreateTopicsResult createTopicsResult = adminClient.createTopics(topics);
-        createTopicsResult.all().get();
+        adminClient.createTopics(topics);
       } catch (TopicExistsException e) {
         /* There is a race condition with the consumer. */
         LOG.debug("Monitoring topic " + topic + " already exists in the cluster.", e);


### PR DESCRIPTION
1 - Minor codestyle spacing
2 - Add SuppressWarnings for "rawtypes"
3 - Add no inspections on rawtypes
4 - Fix `NoSuchFieldError DEFAULT_SSL_PRINCIPAL_MAPPING_RULES` when `KafkaMetricsReporterService` is executed by removing unnecessary elements in the log.

```
Exception in thread “main” java.lang.reflect.InvocationTargetException
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
	at com.linkedin.kmf.KafkaMonitor.<init>(KafkaMonitor.java:86)
	at com.linkedin.kmf.KafkaMonitor.main(KafkaMonitor.java:193)
Caused by: java.lang.NoSuchFieldError: DEFAULT_SSL_PRINCIPAL_MAPPING_RULES
	at kafka.server.Defaults$.<init>(KafkaConfig.scala:224)
	at kafka.server.Defaults$.<clinit>(KafkaConfig.scala)
	at kafka.server.KafkaConfig$.<init>(KafkaConfig.scala:854)
	at kafka.server.KafkaConfig$.<clinit>(KafkaConfig.scala)
	at kafka.server.KafkaConfig.MinInSyncReplicasProp(KafkaConfig.scala)
	at com.linkedin.kmf.common.Utils.createTopicIfNotExists(Utils.java:109)
	at com.linkedin.kmf.services.KafkaMetricsReporterService.<init>(KafkaMetricsReporterService.java:53)
```