### PR TITLE
Change level of logging to debug for offset commit 

### DIFF
--- a/src/main/java/com/linkedin/kmf/services/CommitLatencyMetrics.java
+++ b/src/main/java/com/linkedin/kmf/services/CommitLatencyMetrics.java
@@ -68,7 +68,7 @@ public class CommitLatencyMetrics {
       _inProgressCommit = true;
     } else {
       // inProgressCommit is already set to TRUE;
-      throw new Exception("Offset commit is already in progress.");
+      LOG.debug("Offset commit is already in progress.");
     }
   }
 
@@ -83,7 +83,7 @@ public class CommitLatencyMetrics {
       _inProgressCommit = false;
     } else {
       // inProgressCommit is already set to FALSE;
-      LOG.error("Offset commit is not in progress. CommitLatencyMetrics shouldn't completing a record commit here.");
+      LOG.debug("Offset commit is not in progress. CommitLatencyMetrics shouldn't completing a record commit here.");
     }
   }
 


### PR DESCRIPTION
Offset commit already in progress is not a critical error that should kill the process.
Some commit tasks (Futures threads) take longer to complete and due to the nature of async commits, some commits take longer. Thus, changing level of Logging to debug is sufficient here.


Signed-off-by: Andrew Choi <li_andchoi@microsoft.com>