### PR TITLE
Get topicPartitionsWithRetry and a minor spelling error in services/MultiClusterTopicManagementService

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
 version: 2.1
 jobs:
   build:
-    docker: 
-      - image: circleci/node:4.8.2 # the primary container, where your job's commands are run
+#    docker:
+#      - image: circleci/node:4.8.2 # the primary container, where the job's commands are run
     steps:
       - checkout # check out the code in the project directory
       - run: echo "Kafka Monitor CircleCI"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs: # a collection of steps
       - image: circleci/openjdk:8-jdk-stretch # with this image as the primary container; this is where all `steps` will run.
 
     steps:
-      - # TODO (andrewchoi5)
+      # TODO: populate the necessary steps for CircleCI
       - run: echo "Kafka Monitor CircleCI on GitHub"
 
       # See https://circleci.com/docs/2.0/deployment-integrations/ for deploy examples

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,47 +1,13 @@
-version: 2
-jobs:
-  build:
+version: 2  # use CircleCI 2.0
+
+jobs: # a collection of steps
+  build: # runs not using Workflows must have a `build` job as entry point
 
     docker: # run the steps with Docker
-      - image: circleci/openjdk:8-jdk-stretch # ...with this image as the primary container; this is where all `steps` will run
+      - image: circleci/openjdk:8-jdk-stretch # with this image as the primary container; this is where all `steps` will run.
 
     steps:
-    #      todo
+      - # TODO (andrewchoi5)
+      - run: echo "Kafka Monitor CircleCI on GitHub"
 
-#      - checkout # check out the code in the project directory
-      - run: echo "Kafka Monitor CircleCI"
-
-#
-#version: 2 # use CircleCI 2.0
-#jobs: # a collection of steps
-#  build: # runs not using Workflows must have a `build` job as entry point
-#
-#    working_directory: ~/circleci-demo-java-spring # directory where steps will run
-#
-#
-#
-#    steps: # a collection of executable commands
-#
-#      - checkout # check out source code to working directory
-#
-#      - restore_cache: # restore the saved cache after the first run or if `pom.xml` has changed
-#          # Read about caching dependencies: https://circleci.com/docs/2.0/caching/
-#          key: circleci-demo-java-spring-{{ checksum "pom.xml" }}
-#
-#      - run: mvn dependency:go-offline # gets the project dependencies
-#
-#      - save_cache: # saves the project dependencies
-#          paths:
-#            - ~/.m2
-#          key: circleci-demo-java-spring-{{ checksum "pom.xml" }}
-#
-#      - run: mvn package # run the actual tests
-#
-#      - store_test_results: # uploads the test metadata from the `target/surefire-reports` directory so that it can show up in the CircleCI dashboard.
-#          # Upload test results for display in Test Summary: https://circleci.com/docs/2.0/collect-test-data/
-#          path: target/surefire-reports
-#
-#      - store_artifacts: # store the uberjar as an artifact
-#          # Upload test summary for display in Artifacts: https://circleci.com/docs/2.0/artifacts/
-#          path: target/demo-java-spring-0.0.1-SNAPSHOT.jar
-#      # See https://circleci.com/docs/2.0/deployment-integrations/ for deploy examples
+      # See https://circleci.com/docs/2.0/deployment-integrations/ for deploy examples

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,44 @@
-version: 2.1
+version: 2
 jobs:
   build:
-#    docker:
-#      - image: circleci/node:4.8.2 # the primary container, where the job's commands are run
+
+    docker: # run the steps with Docker
+      - image: circleci/openjdk:8-jdk-stretch # ...with this image as the primary container; this is where all `steps` will run
+
     steps:
       - checkout # check out the code in the project directory
       - run: echo "Kafka Monitor CircleCI"
+#
+#version: 2 # use CircleCI 2.0
+#jobs: # a collection of steps
+#  build: # runs not using Workflows must have a `build` job as entry point
+#
+#    working_directory: ~/circleci-demo-java-spring # directory where steps will run
+#
+#
+#
+#    steps: # a collection of executable commands
+#
+#      - checkout # check out source code to working directory
+#
+#      - restore_cache: # restore the saved cache after the first run or if `pom.xml` has changed
+#          # Read about caching dependencies: https://circleci.com/docs/2.0/caching/
+#          key: circleci-demo-java-spring-{{ checksum "pom.xml" }}
+#
+#      - run: mvn dependency:go-offline # gets the project dependencies
+#
+#      - save_cache: # saves the project dependencies
+#          paths:
+#            - ~/.m2
+#          key: circleci-demo-java-spring-{{ checksum "pom.xml" }}
+#
+#      - run: mvn package # run the actual tests
+#
+#      - store_test_results: # uploads the test metadata from the `target/surefire-reports` directory so that it can show up in the CircleCI dashboard.
+#          # Upload test results for display in Test Summary: https://circleci.com/docs/2.0/collect-test-data/
+#          path: target/surefire-reports
+#
+#      - store_artifacts: # store the uberjar as an artifact
+#          # Upload test summary for display in Artifacts: https://circleci.com/docs/2.0/artifacts/
+#          path: target/demo-java-spring-0.0.1-SNAPSHOT.jar
+#      # See https://circleci.com/docs/2.0/deployment-integrations/ for deploy examples

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,8 +6,11 @@ jobs:
       - image: circleci/openjdk:8-jdk-stretch # ...with this image as the primary container; this is where all `steps` will run
 
     steps:
-      - checkout # check out the code in the project directory
+    #      todo
+
+#      - checkout # check out the code in the project directory
       - run: echo "Kafka Monitor CircleCI"
+
 #
 #version: 2 # use CircleCI 2.0
 #jobs: # a collection of steps

--- a/src/main/java/com/linkedin/kmf/services/MultiClusterTopicManagementService.java
+++ b/src/main/java/com/linkedin/kmf/services/MultiClusterTopicManagementService.java
@@ -165,7 +165,7 @@ public class MultiClusterTopicManagementService implements Service {
         }
 
         /*
-         * The partition number of the monitor topics should be the minimum partition number that satisifies the following conditions:
+         * The partition number of the monitor topics should be the minimum partition number that satisfies the following conditions:
          * - partition number of the monitor topics across all monitored clusters should be the same
          * - partitionNum / brokerNum >= user-configured partitionsToBrokersRatio.
          * - partitionNum >= user-configured minPartitionNum

--- a/src/main/java/com/linkedin/kmf/services/MultiClusterTopicManagementService.java
+++ b/src/main/java/com/linkedin/kmf/services/MultiClusterTopicManagementService.java
@@ -217,12 +217,14 @@ public class MultiClusterTopicManagementService implements Service {
       } catch (Throwable t) {
         /* Need to catch throwable because there is scala API that can throw NoSuchMethodError in runtime
          and such error is not caught by compilation. */
-        LOG.error(_serviceName + "/MultiClusterTopicManagementService will stop due to error.", t);
+        LOG.error(_serviceName
+            + "/MultiClusterTopicManagementService/PreferredLeaderElectionRunnable will stop due to an error.", t);
         stop();
       }
     }
   }
 
+  @SuppressWarnings("FieldCanBeLocal")
   static class TopicManagementHelper {
     private final boolean _topicCreationEnabled;
     private final String _topic;
@@ -233,8 +235,8 @@ public class MultiClusterTopicManagementService implements Service {
     private final TopicFactory _topicFactory;
     private final Properties _topicProperties;
     private boolean _preferredLeaderElectionRequested;
-    private int _requestTimeoutMs;
-    private List _bootstrapServers;
+    private final int _requestTimeoutMs;
+    private final List _bootstrapServers;
     private final AdminClient _adminClient;
 
 


### PR DESCRIPTION
```
1 - minor spelling error in services/MultiClusterTopicManagementService
`satisifies`
2 - Get topicPartitionsWithRetry after Creation of Topic
3 - LOGGER renaming
4 - Mark CircleCI as TODO
```

Signed-off-by: Andrew Choi <li_andchoi@microsoft.com>