### PR TITLE
Partition Assignments when adding new topic partitions

### DIFF
--- a/src/main/java/com/linkedin/kmf/services/MultiClusterTopicManagementService.java
+++ b/src/main/java/com/linkedin/kmf/services/MultiClusterTopicManagementService.java
@@ -322,7 +322,7 @@ public class MultiClusterTopicManagementService implements Service {
         newPartitionsMap.put(_topic, newPartitions);
         CreatePartitionsResult createPartitionsResult = _adminClient.createPartitions(newPartitionsMap);
 
-        // TODO: should we block thread on the createPartitionsResult future?
+        createPartitionsResult.all().get();
       }
     }
 

--- a/src/main/java/com/linkedin/kmf/services/MultiClusterTopicManagementService.java
+++ b/src/main/java/com/linkedin/kmf/services/MultiClusterTopicManagementService.java
@@ -333,7 +333,9 @@ public class MultiClusterTopicManagementService implements Service {
       // .increaseTo(6, asList(asList(1, 2),
       //                       asList(2, 3),
       //                       asList(3, 1)))
-      // partition 3's PL will be broker 1, partition 4's PL will be broker 2 and partition 5's PL will be broker 3.
+      // partition 3's preferred leader will be broker 1,
+      // partition 4's preferred leader will be broker 2 and
+      // partition 5's preferred leader will be broker 3.
       List<List<Integer>> newPartitionAssignments = new ArrayList<>(new ArrayList<>());
       int partitionDifference = minPartitionNum - partitionNum;
 
@@ -349,7 +351,7 @@ public class MultiClusterTopicManagementService implements Service {
       }
 
       // follower assignments -
-      // Regardless of the partition/replica assignments here, `maybeReassignPartitionAndElectLeader()`
+      // Regardless of the partition/replica assignments here, maybeReassignPartitionAndElectLeader()
       // will reassign the partition as needed periodically.
       for (List<Integer> replicas : newPartitionAssignments) {
         for (BrokerMetadata broker : brokers) {

--- a/src/main/java/com/linkedin/kmf/services/MultiClusterTopicManagementService.java
+++ b/src/main/java/com/linkedin/kmf/services/MultiClusterTopicManagementService.java
@@ -367,8 +367,6 @@ public class MultiClusterTopicManagementService implements Service {
      */
     int numPartitions() throws InterruptedException, ExecutionException {
 
-      // TODO (andrewchoi5): connect this to unit testing method for testing maybeAddPartitions!
-
       return _adminClient.describeTopics(Collections.singleton(_topic)).values().get(_topic).get().partitions().size();
     }
 

--- a/src/test/java/com/linkedin/kmf/services/MultiClusterTopicManagementServiceTest.java
+++ b/src/test/java/com/linkedin/kmf/services/MultiClusterTopicManagementServiceTest.java
@@ -11,9 +11,8 @@
 package com.linkedin.kmf.services;
 
 import com.linkedin.kmf.topicfactory.TopicFactory;
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -43,7 +42,7 @@ import scala.Option;
 public class MultiClusterTopicManagementServiceTest {
 
   private static final String SERVICE_TEST_TOPIC = "xinfra-monitor-Multi-Cluster-Topic-Management-Service-Test-topic";
-  private static List<Node> nodeSet;
+  private static Set<Node> nodeSet;
   private MultiClusterTopicManagementService.TopicManagementHelper _topicManagementHelper;
   private CreateTopicsResult _createTopicsResult;
   private Map<String, KafkaFuture<Void>> _kafkaFutureMap;
@@ -55,7 +54,7 @@ public class MultiClusterTopicManagementServiceTest {
     _kafkaFutureMap = Mockito.mock(Map.class);
     _kafkaFuture = Mockito.mock(KafkaFuture.class);
 
-    nodeSet = new ArrayList<>();
+    nodeSet = new LinkedHashSet<>();
     nodeSet.add(new Node(1, "host-1", 2132));
     nodeSet.add(new Node(2, "host-2", 2133));
     nodeSet.add(new Node(3, "host-3", 2134));
@@ -77,9 +76,9 @@ public class MultiClusterTopicManagementServiceTest {
     System.out.println("Finished " + this.getClass().getCanonicalName().toLowerCase() + ".");
   }
 
-  @Test(invocationCount = 10000)
+  @Test(invocationCount = 2)
   protected void maybeAddPartitionsTest() {
-    Set<BrokerMetadata> brokerMetadataSet = new HashSet<>();
+    Set<BrokerMetadata> brokerMetadataSet = new LinkedHashSet<>();
     for (Node broker : nodeSet) {
       brokerMetadataSet.add(new BrokerMetadata(broker.id(), Option.apply(broker.rack())));
     }
@@ -88,12 +87,12 @@ public class MultiClusterTopicManagementServiceTest {
     Assert.assertNotNull(newPartitionAssignments);
 
     System.out.println(newPartitionAssignments);
-    Assert.assertEquals(newPartitionAssignments.get(0).get(0).intValue(), 6);
+    Assert.assertEquals(newPartitionAssignments.get(0).get(0).intValue(), 1);
     Assert.assertEquals(newPartitionAssignments.get(1).get(0).intValue(), 2);
     Assert.assertEquals(newPartitionAssignments.get(2).get(0).intValue(), 3);
     Assert.assertEquals(newPartitionAssignments.get(3).get(0).intValue(), 4);
-    Assert.assertEquals(newPartitionAssignments.get(4).get(0).intValue(), 8);
-    Assert.assertEquals(newPartitionAssignments.get(5).get(0).intValue(), 1);
+    Assert.assertEquals(newPartitionAssignments.get(4).get(0).intValue(), 5);
+    Assert.assertEquals(newPartitionAssignments.get(5).get(0).intValue(), 6);
   }
 
   @Test

--- a/src/test/java/com/linkedin/kmf/services/MultiClusterTopicManagementServiceTest.java
+++ b/src/test/java/com/linkedin/kmf/services/MultiClusterTopicManagementServiceTest.java
@@ -11,13 +11,11 @@
 package com.linkedin.kmf.services;
 
 import com.linkedin.kmf.topicfactory.TopicFactory;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ExecutionException;
 import kafka.admin.BrokerMetadata;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.CreateTopicsResult;
@@ -26,7 +24,6 @@ import org.apache.kafka.clients.admin.DescribeTopicsResult;
 import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.Node;
-import org.apache.kafka.common.TopicPartitionInfo;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -51,7 +48,7 @@ public class MultiClusterTopicManagementServiceTest {
   private KafkaFuture<Void> _kafkaFuture;
 
   @BeforeMethod
-  private void startTest() throws ExecutionException, InterruptedException {
+  private void startTest() {
     _createTopicsResult = Mockito.mock(CreateTopicsResult.class);
     _kafkaFutureMap = Mockito.mock(Map.class);
     _kafkaFuture = Mockito.mock(KafkaFuture.class);
@@ -71,41 +68,6 @@ public class MultiClusterTopicManagementServiceTest {
     _topicManagementHelper._adminClient = Mockito.mock(AdminClient.class);
     _topicManagementHelper._topicFactory = Mockito.mock(TopicFactory.class);
     _topicManagementHelper._topicCreationEnabled = true;
-
-    List<TopicPartitionInfo> topicPartitions = new ArrayList<>();
-    topicPartitions.add(new TopicPartitionInfo(1, new Node(1, "host-1", 3521), new ArrayList<>(), new ArrayList<>()));
-    topicPartitions.add(new TopicPartitionInfo(2, new Node(2, "host-2", 3522), new ArrayList<>(), new ArrayList<>()));
-    topicPartitions.add(new TopicPartitionInfo(3, new Node(3, "host-3", 3523), new ArrayList<>(), new ArrayList<>()));
-    topicPartitions.add(new TopicPartitionInfo(4, new Node(4, "host-4", 3524), new ArrayList<>(), new ArrayList<>()));
-    topicPartitions.add(new TopicPartitionInfo(5, new Node(5, "host-5", 3525), new ArrayList<>(), new ArrayList<>()));
-
-    Mockito.when(_topicManagementHelper._adminClient.describeTopics(Collections.singleton(SERVICE_TEST_TOPIC)))
-        .thenReturn(Mockito.mock(DescribeTopicsResult.class));
-    Mockito.when(_topicManagementHelper._adminClient.describeTopics(Collections.singleton(SERVICE_TEST_TOPIC)).values())
-        .thenReturn(Mockito.mock(Map.class));
-    Mockito.when(_topicManagementHelper._adminClient.describeTopics(Collections.singleton(SERVICE_TEST_TOPIC))
-        .values()
-        .get(SERVICE_TEST_TOPIC)).thenReturn(Mockito.mock(KafkaFuture.class));
-    Mockito.when(_topicManagementHelper._adminClient.describeTopics(Collections.singleton(SERVICE_TEST_TOPIC))
-        .values()
-        .get(SERVICE_TEST_TOPIC)
-        .get()).thenReturn(Mockito.mock(TopicDescription.class));
-    Mockito.when(_topicManagementHelper._adminClient.describeTopics(Collections.singleton(SERVICE_TEST_TOPIC))
-        .values()
-        .get(SERVICE_TEST_TOPIC)
-        .get()
-        .name()).thenReturn(SERVICE_TEST_TOPIC);
-    Mockito.when(_topicManagementHelper._adminClient.describeTopics(Collections.singleton(SERVICE_TEST_TOPIC))
-        .values()
-        .get(SERVICE_TEST_TOPIC)
-        .get()
-        .partitions()).thenReturn(topicPartitions);
-
-    Mockito.when(_topicManagementHelper._adminClient.describeCluster())
-        .thenReturn(Mockito.mock(DescribeClusterResult.class));
-    Mockito.when(_topicManagementHelper._adminClient.describeCluster().nodes())
-        .thenReturn(Mockito.mock(KafkaFuture.class));
-    Mockito.when(_topicManagementHelper._adminClient.describeCluster().nodes().get()).thenReturn(nodeSet);
   }
 
   @AfterMethod

--- a/src/test/java/com/linkedin/kmf/services/MultiClusterTopicManagementServiceTest.java
+++ b/src/test/java/com/linkedin/kmf/services/MultiClusterTopicManagementServiceTest.java
@@ -11,7 +11,6 @@
 package com.linkedin.kmf.services;
 
 import com.linkedin.kmf.topicfactory.TopicFactory;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -87,44 +86,13 @@ public class MultiClusterTopicManagementServiceTest {
         MultiClusterTopicManagementService.TopicManagementHelper.newPartitionAssignments(11, 5, brokerMetadataSet, 4);
     Assert.assertNotNull(newPartitionAssignments);
 
-    List<List<Integer>> newPartitionAssignmentsList = new ArrayList<>();
-    List<Integer> list = new ArrayList<>();
-    list.add(6);
-    list.add(2);
-    list.add(4);
-    list.add(3);
-    newPartitionAssignmentsList.add(list);
-    list = new ArrayList<>();
-    list.add(2);
-    list.add(6);
-    list.add(4);
-    list.add(3);
-    newPartitionAssignmentsList.add(list);
-    list = new ArrayList<>();
-    list.add(4);
-    list.add(6);
-    list.add(2);
-    list.add(3);
-    newPartitionAssignmentsList.add(list);
-    list = new ArrayList<>();
-    list.add(3);
-    list.add(6);
-    list.add(2);
-    list.add(4);
-    newPartitionAssignmentsList.add(list);
-    list = new ArrayList<>();
-    list.add(8);
-    list.add(6);
-    list.add(2);
-    list.add(4);
-    newPartitionAssignmentsList.add(list);
-    list = new ArrayList<>();
-    list.add(5);
-    list.add(6);
-    list.add(2);
-    list.add(4);
-    newPartitionAssignmentsList.add(list);
-    Assert.assertEquals(newPartitionAssignmentsList, newPartitionAssignments);
+    System.out.println(newPartitionAssignments);
+    Assert.assertEquals(newPartitionAssignments.get(0).get(0).intValue(), 6);
+    Assert.assertEquals(newPartitionAssignments.get(1).get(0).intValue(), 2);
+    Assert.assertEquals(newPartitionAssignments.get(2).get(0).intValue(), 4);
+    Assert.assertEquals(newPartitionAssignments.get(3).get(0).intValue(), 3);
+    Assert.assertEquals(newPartitionAssignments.get(4).get(0).intValue(), 8);
+    Assert.assertEquals(newPartitionAssignments.get(5).get(0).intValue(), 5);
   }
 
   @Test

--- a/src/test/java/com/linkedin/kmf/services/MultiClusterTopicManagementServiceTest.java
+++ b/src/test/java/com/linkedin/kmf/services/MultiClusterTopicManagementServiceTest.java
@@ -11,6 +11,7 @@
 package com.linkedin.kmf.services;
 
 import com.linkedin.kmf.topicfactory.TopicFactory;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -76,7 +77,7 @@ public class MultiClusterTopicManagementServiceTest {
     System.out.println("Finished " + this.getClass().getCanonicalName().toLowerCase() + ".");
   }
 
-  @Test
+  @Test(invocationCount = 10000)
   protected void maybeAddPartitionsTest() {
     Set<BrokerMetadata> brokerMetadataSet = new HashSet<>();
     for (Node broker : nodeSet) {
@@ -86,8 +87,44 @@ public class MultiClusterTopicManagementServiceTest {
         MultiClusterTopicManagementService.TopicManagementHelper.newPartitionAssignments(11, 5, brokerMetadataSet, 4);
     Assert.assertNotNull(newPartitionAssignments);
 
-    Assert.assertEquals(newPartitionAssignments.toString(),
-        "[[6, 2, 4, 3], [2, 6, 4, 3], [4, 6, 2, 3], [3, 6, 2, 4], [8, 6, 2, 4], [5, 6, 2, 4]]");
+    List<List<Integer>> newPartitionAssignmentsList = new ArrayList<>();
+    List<Integer> list = new ArrayList<>();
+    list.add(6);
+    list.add(2);
+    list.add(4);
+    list.add(3);
+    newPartitionAssignmentsList.add(list);
+    list = new ArrayList<>();
+    list.add(2);
+    list.add(6);
+    list.add(4);
+    list.add(3);
+    newPartitionAssignmentsList.add(list);
+    list = new ArrayList<>();
+    list.add(4);
+    list.add(6);
+    list.add(2);
+    list.add(3);
+    newPartitionAssignmentsList.add(list);
+    list = new ArrayList<>();
+    list.add(3);
+    list.add(6);
+    list.add(2);
+    list.add(4);
+    newPartitionAssignmentsList.add(list);
+    list = new ArrayList<>();
+    list.add(8);
+    list.add(6);
+    list.add(2);
+    list.add(4);
+    newPartitionAssignmentsList.add(list);
+    list = new ArrayList<>();
+    list.add(5);
+    list.add(6);
+    list.add(2);
+    list.add(4);
+    newPartitionAssignmentsList.add(list);
+    Assert.assertEquals(newPartitionAssignmentsList, newPartitionAssignments);
   }
 
   @Test

--- a/src/test/java/com/linkedin/kmf/services/MultiClusterTopicManagementServiceTest.java
+++ b/src/test/java/com/linkedin/kmf/services/MultiClusterTopicManagementServiceTest.java
@@ -40,6 +40,7 @@ import scala.Option;
 @SuppressWarnings("unchecked")
 @Test
 public class MultiClusterTopicManagementServiceTest {
+
   private static final String SERVICE_TEST_TOPIC = "xinfra-monitor-Multi-Cluster-Topic-Management-Service-Test-topic";
   private static Set<Node> nodeSet;
   private MultiClusterTopicManagementService.TopicManagementHelper _topicManagementHelper;

--- a/src/test/java/com/linkedin/kmf/services/MultiClusterTopicManagementServiceTest.java
+++ b/src/test/java/com/linkedin/kmf/services/MultiClusterTopicManagementServiceTest.java
@@ -85,8 +85,6 @@ public class MultiClusterTopicManagementServiceTest {
         MultiClusterTopicManagementService.TopicManagementHelper.newPartitionAssignments(11, 5, brokerMetadataSet, 4);
     Assert.assertNotNull(newPartitionAssignments);
 
-    System.out.println(newPartitionAssignments);
-
     Assert.assertEquals(newPartitionAssignments.toString(),
         "[[6, 2, 4, 3], [2, 6, 4, 3], [4, 6, 2, 3], [3, 6, 2, 4], [8, 6, 2, 4], [5, 6, 2, 4]]");
   }

--- a/src/test/java/com/linkedin/kmf/services/MultiClusterTopicManagementServiceTest.java
+++ b/src/test/java/com/linkedin/kmf/services/MultiClusterTopicManagementServiceTest.java
@@ -11,6 +11,7 @@
 package com.linkedin.kmf.services;
 
 import com.linkedin.kmf.topicfactory.TopicFactory;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -42,7 +43,7 @@ import scala.Option;
 public class MultiClusterTopicManagementServiceTest {
 
   private static final String SERVICE_TEST_TOPIC = "xinfra-monitor-Multi-Cluster-Topic-Management-Service-Test-topic";
-  private static Set<Node> nodeSet;
+  private static List<Node> nodeSet;
   private MultiClusterTopicManagementService.TopicManagementHelper _topicManagementHelper;
   private CreateTopicsResult _createTopicsResult;
   private Map<String, KafkaFuture<Void>> _kafkaFutureMap;
@@ -54,7 +55,7 @@ public class MultiClusterTopicManagementServiceTest {
     _kafkaFutureMap = Mockito.mock(Map.class);
     _kafkaFuture = Mockito.mock(KafkaFuture.class);
 
-    nodeSet = new HashSet<>();
+    nodeSet = new ArrayList<>();
     nodeSet.add(new Node(1, "host-1", 2132));
     nodeSet.add(new Node(2, "host-2", 2133));
     nodeSet.add(new Node(3, "host-3", 2134));
@@ -89,10 +90,10 @@ public class MultiClusterTopicManagementServiceTest {
     System.out.println(newPartitionAssignments);
     Assert.assertEquals(newPartitionAssignments.get(0).get(0).intValue(), 6);
     Assert.assertEquals(newPartitionAssignments.get(1).get(0).intValue(), 2);
-    Assert.assertEquals(newPartitionAssignments.get(2).get(0).intValue(), 4);
-    Assert.assertEquals(newPartitionAssignments.get(3).get(0).intValue(), 3);
+    Assert.assertEquals(newPartitionAssignments.get(2).get(0).intValue(), 3);
+    Assert.assertEquals(newPartitionAssignments.get(3).get(0).intValue(), 4);
     Assert.assertEquals(newPartitionAssignments.get(4).get(0).intValue(), 8);
-    Assert.assertEquals(newPartitionAssignments.get(5).get(0).intValue(), 5);
+    Assert.assertEquals(newPartitionAssignments.get(5).get(0).intValue(), 1);
   }
 
   @Test


### PR DESCRIPTION
- Random assignment of partition assignments when adding partitions periodically
- Justifications: regardless of the partition/replica assignments here, `maybeReassignPartitionAndElectLeader()` will reassign the partition as needed periodically.
 

`Signed-off-by: Andrew Choi <li_andchoi@microsoft.com>`