### PR TITLE
Ensure KafkaMetricsReporterSerivce carries the correct constructor parameters.

### DIFF
--- a/src/main/java/com/linkedin/kmf/KafkaMonitor.java
+++ b/src/main/java/com/linkedin/kmf/KafkaMonitor.java
@@ -27,6 +27,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.common.metrics.JmxReporter;
 import org.apache.kafka.common.metrics.MetricConfig;
 import org.apache.kafka.common.metrics.Metrics;
@@ -60,7 +61,7 @@ public class KafkaMonitor {
    * For example, if there are 10 clusters to be monitored, then this Constructor will create 10 * num_apps_per_cluster
    * and 10 * num_services_per_cluster.
    * @param allClusterProps the properties of ALL kafka clusters for which apps and services need to be appended.
-   * @throws Exception
+   * @throws Exception when exception occurs while assigning Apps and Services
    */
   @SuppressWarnings({"rawtypes", "unchecked"})
   public KafkaMonitor(Map<String, Map> allClusterProps) throws Exception {
@@ -80,13 +81,21 @@ public class KafkaMonitor {
         _apps.put(name, clusterApp);
       } else if (Service.class.isAssignableFrom(aClass)) {
         Constructor<?>[] constructors = Class.forName(className).getConstructors();
-        if (this.constructorContainsFuture(constructors)) {
+        if (this.constructorContainsClass(constructors, CompletableFuture.class)) {
+          // for ConsumeService public constructor
           CompletableFuture<Void> completableFuture = new CompletableFuture<>();
           completableFuture.complete(null);
           ConsumerFactoryImpl consumerFactory = new ConsumerFactoryImpl(props);
           Service service = (Service) Class.forName(className)
               .getConstructor(String.class, CompletableFuture.class, ConsumerFactory.class)
               .newInstance(name, completableFuture, consumerFactory);
+          _services.put(name, service);
+        } else if (this.constructorContainsClass(constructors, AdminClient.class)) {
+          // for KafkaMetricsReporterService constructor
+          AdminClient adminClient = AdminClient.create(props);
+          Service service = (Service) Class.forName(className)
+              .getConstructor(Map.class, String.class, AdminClient.class)
+              .newInstance(props, name, adminClient);
           _services.put(name, service);
         } else {
           Service service = (Service) Class.forName(className).getConstructor(Map.class, String.class).newInstance(props, name);
@@ -105,9 +114,9 @@ public class KafkaMonitor {
       (config, now) -> _offlineRunnables.size());
   }
 
-  private boolean constructorContainsFuture(Constructor<?>[] constructors) {
+  private boolean constructorContainsClass(Constructor<?>[] constructors, Class<?> classObject) {
     for (int n = 0; n < constructors[0].getParameterTypes().length; ++n) {
-      if (constructors[0].getParameterTypes()[n].equals(CompletableFuture.class)) {
+      if (constructors[0].getParameterTypes()[n].equals(classObject)) {
         return true;
       }
     }


### PR DESCRIPTION
1. Ensure KafkaMetricsReporterSerivce carries the correct constructor parameters.
2. Abstract out the helper methods with `constructorContainsClass`
3. The way Service Instantiations are done within Kafka Monitor will be updated with `https://github.com/linkedin/kafka-monitor/pull/257`.

--------------------
testing:

```
	produce.treat.zero.throughput.as.unavailable = true
	topic = kafka-monitor-topic1
	zookeeper.connect = localhost:2181
 (com.linkedin.kmf.services.configs.ProduceServiceConfig)
[2020-05-29 14:34:57,457] INFO produce-service/ProduceService is initialized. (com.linkedin.kmf.services.ProduceService)
[2020-05-29 14:34:57,468] INFO KafkaMetricsReporterServiceConfig values:
	bootstrap.servers = localhost:9092
	report.interval.sec = 3
	report.kafka.topic.replication.factor = 1
	report.metrics.list = [kmf.services:type=produce-service,name=*:produce-availability-avg, kmf.services:type=consume-service,name=*:consume-availability-avg, kmf.services:type=produce-service,name=*:records-produced-total, kmf.services:type=consume-service,name=*:records-consumed-total, kmf.services:type=consume-service,name=*:records-lost-total, kmf.services:type=consume-service,name=*:records-duplicated-total, kmf.services:type=consume-service,name=*:records-delay-ms-avg, kmf.services:type=produce-service,name=*:records-produced-rate, kmf.services:type=produce-service,name=*:produce-error-rate, kmf.services:type=consume-service,name=*:consume-error-rate]
	topic = kafka-monitor-topic1
	zookeeper.connect = localhost:2181
 (com.linkedin.kmf.services.configs.KafkaMetricsReporterServiceConfig)
[2020-05-29 14:34:57,694] INFO CreateTopicsResult: {kafka-monitor-topic1=KafkaFuture{value=null,exception=null,done=true}}. (com.linkedin.kmf.common.Utils)
[2020-05-29 14:34:57,694] INFO Created monitoring topic kafka-monitor-topic1 in cluster with 1 partitions and replication factor of 1. (com.linkedin.kmf.common.Utils)
[2020-05-29 14:34:57,694] INFO Completed the topic creation if it doesn't exist for kafka-monitor-topic1. (com.linkedin.kmf.common.Utils)
[2020-05-29 14:34:57,706] INFO produce-service/ProduceService started (com.linkedin.kmf.services.ProduceService)
[2020-05-29 14:34:57,707] INFO reporter-kafka-service/KafkaMetricsReporterService has started. (com.linkedin.kmf.services.KafkaMetricsReporterService)
[2020-05-29 14:34:57,707] INFO Xinfra Monitor (KafkaMonitor) started. (com.linkedin.kmf.KafkaMonitor)
[2020-05-29 14:35:00,722] INFO Kafka Metrics Reporter sending metrics = {
  "kmf.services:name=produce-service,type=produce-service:records-produced-rate" : "0.4514446227929374",
  "kmf.services:name=produce-service,type=produce-service:records-produced-total" : "27.0",
  "kmf.services:name=produce-service,type=produce-service:produce-availability-avg" : "1.0",
  "kmf.services:name=produce-service,type=produce-service:produce-error-rate" : "0.0"
} (com.linkedin.kmf.services.KafkaMetricsReporterService)
[2020-05-29 14:35:03,708] INFO Kafka Metrics Reporter sending metrics = {
  "kmf.services:name=produce-service,type=produce-service:records-produced-rate" : "0.9363765571440515",
  "kmf.services:name=produce-service,type=produce-service:records-produced-total" : "56.0",
  "kmf.services:name=produce-service,type=produce-service:produce-availability-avg" : "1.0",
  "kmf.services:name=produce-service,type=produce-service:produce-error-rate" : "0.0"
} (com.linkedin.kmf.services.KafkaMetricsReporterService)
[2020-05-29 14:35:06,708] INFO Kafka Metrics Reporter sending metrics = {
  "kmf.services:name=produce-service,type=produce-service:records-produced-rate" : "1.4045648357160772",
  "kmf.services:name=produce-service,type=produce-service:records-produced-total" : "84.0",
  "kmf.services:name=produce-service,type=produce-service:produce-availability-avg" : "1.0",
  "kmf.services:name=produce-service,type=produce-service:produce-error-rate" : "0.0"
} (com.linkedin.kmf.services.KafkaMetricsReporterService)
[2020-05-29 14:35:09,709] INFO Kafka Metrics Reporter sending metrics = {
  "kmf.services:name=produce-service,type=produce-service:records-produced-rate" : "1.8894425308497476",
  "kmf.services:name=produce-service,type=produce-service:records-produced-total" : "113.0",
  "kmf.services:name=produce-service,type=produce-service:produce-availability-avg" : "1.0",
  "kmf.services:name=produce-service,type=produce-service:produce-error-rate" : "0.0"
} (com.linkedin.kmf.services.KafkaMetricsReporterService)
[2020-05-29 14:35:12,712] INFO Kafka Metrics Reporter sending metrics = {
  "kmf.services:name=produce-service,type=produce-service:records-produced-rate" : "2.3742246150244948",
  "kmf.services:name=produce-service,type=produce-service:records-produced-total" : "142.0",
  "kmf.services:name=produce-service,type=produce-service:produce-availability-avg" : "1.0",
  "kmf.services:name=produce-service,type=produce-service:produce-error-rate" : "0.0"
} (com.linkedin.kmf.services.KafkaMetricsReporterService)
[2020-05-29 14:35:15,709] INFO Kafka Metrics Reporter sending metrics = {
  "kmf.services:name=produce-service,type=produce-service:records-produced-rate" : "2.842571691330156",
  "kmf.services:name=produce-service,type=produce-service:records-produced-total" : "170.0",
  "kmf.services:name=produce-service,type=produce-service:produce-availability-avg" : "1.0",
  "kmf.services:name=produce-service,type=produce-service:produce-error-rate" : "0.0"
} (com.linkedin.kmf.services.KafkaMetricsReporterService)
f[2020-05-29 14:35:18,712] INFO Kafka Metrics Reporter sending metrics = {
  "kmf.services:name=produce-service,type=produce-service:records-produced-rate" : "3.3273140716960943",
  "kmf.services:name=produce-service,type=produce-service:records-produced-total" : "199.0",
  "kmf.services:name=produce-service,type=produce-service:produce-availability-avg" : "1.0",
  "kmf.services:name=produce-service,type=produce-service:produce-error-rate" : "0.0"
} (com.linkedin.kmf.services.KafkaMetricsReporterService)
```

`Signed-off-by: Andrew Choi <li_andchoi@microsoft.com>`