### PR TITLE
Xinfra Monitor scala 2.12

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ allprojects {
     compile 'net.savantly:graphite-client:1.1.0-RELEASE'
     compile 'com.timgroup:java-statsd-client:3.0.1'
     compile 'com.signalfx.public:signalfx-codahale:0.0.47'
-    compile group: 'org.apache.kafka', name: 'kafka_2.13', version: '2.4.1'
+    compile group: 'org.apache.kafka', name: 'kafka_2.12', version: '2.4.1'
     compile group: 'org.apache.kafka', name: 'kafka-clients', version: '2.4.1'
     testCompile 'org.mockito:mockito-core:2.24.0'
     testCompile 'org.testng:testng:6.8.8'


### PR DESCRIPTION
Most clients and mp at linkedin use scala version_2.12/2.11 anyway so it makes sense for the open source to monitor clusters with scala version 2.12 as well.

tested with local deploys.

Signed-off-by: Andrew Choi <li_andchoi@microsoft.com>