### PR TITLE
Update Providing number of assignments by which the number of partitions was increased

### DIFF
--- a/src/test/java/com/linkedin/kmf/services/MultiClusterTopicManagementServiceTest.java
+++ b/src/test/java/com/linkedin/kmf/services/MultiClusterTopicManagementServiceTest.java
@@ -60,9 +60,11 @@ public class MultiClusterTopicManagementServiceTest {
     nodeSet.add(new Node(3, "host-3", 2134));
     nodeSet.add(new Node(4, "host-4", 2135));
     nodeSet.add(new Node(5, "host-5", 2136));
-    nodeSet.add(new Node(6, "host-5", 2136));
-    nodeSet.add(new Node(7, "host-5", 2136));
-    nodeSet.add(new Node(8, "host-5", 2136));
+    nodeSet.add(new Node(6, "host-5", 2137));
+    nodeSet.add(new Node(7, "host-5", 2138));
+    nodeSet.add(new Node(8, "host-5", 2139));
+    nodeSet.add(new Node(9, "host-5", 2140));
+    nodeSet.add(new Node(10, "host-5", 2141));
 
     _topicManagementHelper = Mockito.mock(MultiClusterTopicManagementService.TopicManagementHelper.class);
     _topicManagementHelper._topic = SERVICE_TEST_TOPIC;
@@ -82,17 +84,18 @@ public class MultiClusterTopicManagementServiceTest {
     for (Node broker : nodeSet) {
       brokerMetadataSet.add(new BrokerMetadata(broker.id(), Option.apply(broker.rack())));
     }
+
+    int minPartitionNum = 14;
+    int partitionNum = 5;
+    int rf = 4;
+
     List<List<Integer>> newPartitionAssignments =
-        MultiClusterTopicManagementService.TopicManagementHelper.newPartitionAssignments(390, 5, brokerMetadataSet, 4);
+        MultiClusterTopicManagementService.TopicManagementHelper.newPartitionAssignments(minPartitionNum, partitionNum, brokerMetadataSet, rf);
     Assert.assertNotNull(newPartitionAssignments);
 
     System.out.println(newPartitionAssignments);
-    Assert.assertEquals(newPartitionAssignments.get(0).get(0).intValue(), 1);
-    Assert.assertEquals(newPartitionAssignments.get(1).get(0).intValue(), 2);
-    Assert.assertEquals(newPartitionAssignments.get(2).get(0).intValue(), 3);
-    Assert.assertEquals(newPartitionAssignments.get(3).get(0).intValue(), 4);
-    Assert.assertEquals(newPartitionAssignments.get(4).get(0).intValue(), 5);
-    Assert.assertEquals(newPartitionAssignments.get(5).get(0).intValue(), 6);
+    Assert.assertEquals(newPartitionAssignments.size(), minPartitionNum - partitionNum);
+    Assert.assertEquals(newPartitionAssignments.get(0).size(), rf);
   }
 
   @Test

--- a/src/test/java/com/linkedin/kmf/services/MultiClusterTopicManagementServiceTest.java
+++ b/src/test/java/com/linkedin/kmf/services/MultiClusterTopicManagementServiceTest.java
@@ -83,7 +83,7 @@ public class MultiClusterTopicManagementServiceTest {
       brokerMetadataSet.add(new BrokerMetadata(broker.id(), Option.apply(broker.rack())));
     }
     List<List<Integer>> newPartitionAssignments =
-        MultiClusterTopicManagementService.TopicManagementHelper.newPartitionAssignments(11, 5, brokerMetadataSet, 4);
+        MultiClusterTopicManagementService.TopicManagementHelper.newPartitionAssignments(390, 5, brokerMetadataSet, 4);
     Assert.assertNotNull(newPartitionAssignments);
 
     System.out.println(newPartitionAssignments);


### PR DESCRIPTION
The partition count you are increasing the partitions by should equal the actual size of the new partition assignments.

This PR achieves this. 

For instance: 
old partitions count = 5
new partitions count = 11

increase in partitions = 6
the size of the new partition assignments ought to be be 6 also.

**Note: Random assignment is adequate here because the periodic runnable for maybeReassignPartitions runs the reassignment operation on an interval.**

```
2020/06/04 17:00:32.200 ERROR [MultiClusterTopicManagementService] [krc-multi-cluster-topic-management-service] [kafka-monitoring] [] krc/MultiClusterTopicManagementService will stop due to error.
java.util.concurrent.ExecutionException: org.apache.kafka.common.errors.InvalidReplicaAssignmentException: Increasing the number of partitions by 390 but 10 assignments provided.
        at org.apache.kafka.common.internals.KafkaFutureImpl.wrapAndThrow(KafkaFutureImpl.java:45) ~[kafka-clients-2.3.0.20.jar:?]
        at org.apache.kafka.common.internals.KafkaFutureImpl.access$000(KafkaFutureImpl.java:32) ~[kafka-clients-2.3.0.20.jar:?]
        at org.apache.kafka.common.internals.KafkaFutureImpl$SingleWaiter.await(KafkaFutureImpl.java:89) ~[kafka-clients-2.3.0.20.jar:?]
        at org.apache.kafka.common.internals.KafkaFutureImpl.get(KafkaFutureImpl.java:260) ~[kafka-clients-2.3.0.20.jar:?]
        at com.linkedin.kmf.services.MultiClusterTopicManagementService$TopicManagementHelper.maybeAddPartitions(MultiClusterTopicManagementService.java:323) ~[kafka-monitor-2.2.6.jar:2.2.6]
        at com.linkedin.kmf.services.MultiClusterTopicManagementService$TopicManagementRunnable.run(MultiClusterTopicManagementService.java:177) [kafka-monitor-2.2.6.jar:2.2.6]
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) [?:1.8.0_172]
        at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308) [?:1.8.0_172]
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180) [?:1.8.0_172]
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294) [?:1.8.0_172]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:1.8.0_172]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:1.8.0_172]
        at java.lang.Thread.run(Thread.java:748) [?:1.8.0_172]
Caused by: org.apache.kafka.common.errors.InvalidReplicaAssignmentException: Increasing the number of partitions by 390 but 10 assignments provided.
```


`Signed-off-by: Andrew Choi <li_andchoi@microsoft.com>`