### PR TITLE
Travis CI clean up instead of the deprecated skip_cleanup under .travis YML file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ cache:
 deploy:
   provider: script
   script: bash -v scripts/publishToBintray.sh
-  skip_cleanup: true
+  cleanup: true
   on:
     all_branches: true
     tags: true


### PR DESCRIPTION
1. Travis CI has deprecated the use of the key `skip_cleanup`. 
2. Thus, have Travis CI use clean up instead of the deprecated skip_cleanup under .travis YML file

Why?
 - Such that the following tests don't fail.

```
1. continuous-integration/travis-ci/pr — The Travis CI build passed
2. continuous-integration/travis-ci/push — The Travis CI build passed
```

`Signed-off-by: Andrew Choi <li_andchoi@microsoft.com>`