### PR TITLE
Addition of cluster-topic-manipulation-service and reporter-kafka-service in the xinfra monitor config

### DIFF
--- a/config/xinfra-monitor.properties
+++ b/config/xinfra-monitor.properties
@@ -99,7 +99,12 @@
         "kmf.services:type=commit-latency-service,name=*:commit-offset-latency-ms-9999th",
         "kmf.services:type=commit-availability-service,name=*:failed-commit-offsets-total"
     ]
-  }
+  },
+
+  "cluster-topic-manipulation-service":{
+     "class.name":"com.linkedin.kmf.services.ClusterTopicManipulationService",
+     "bootstrap.servers":"localhost:9092,localhost:9093"
+  },
 
 #  Example produce-service to produce messages to cluster
 #    "produce-service": {
@@ -135,29 +140,29 @@
 #      "kmf.services:type=produce-service,name=*:produce-availability-avg",
 #      "kmf.services:type=consume-service,name=*:consume-availability-avg"
 #     ]
-#  }
+#  },
 
 #  Example kafka-service to report metrics
-#  "reporter-kafka-service": {
-#    "class.name": "com.linkedin.kmf.services.KafkaMetricsReporterService",
-#    "report.interval.sec": 3,
-#    "zookeeper.connect": "localhost:2181",
-#    "bootstrap.servers": "localhost:9092",
-#    "topic": "xinfra-monitor-topic-metrics",
-#    "report.kafka.topic.replication.factor": 1,
-#    "report.metrics.list": [
-#      "kmf.services:type=produce-service,name=*:produce-availability-avg",
-#      "kmf.services:type=consume-service,name=*:consume-availability-avg",
-#      "kmf.services:type=produce-service,name=*:records-produced-total",
-#      "kmf.services:type=consume-service,name=*:records-consumed-total",
-#      "kmf.services:type=consume-service,name=*:records-lost-total",
-#      "kmf.services:type=consume-service,name=*:records-duplicated-total",
-#      "kmf.services:type=consume-service,name=*:records-delay-ms-avg",
-#      "kmf.services:type=produce-service,name=*:records-produced-rate",
-#      "kmf.services:type=produce-service,name=*:produce-error-rate",
-#      "kmf.services:type=consume-service,name=*:consume-error-rate"
-#    ]
-#  }
+  "reporter-kafka-service": {
+    "class.name": "com.linkedin.kmf.services.KafkaMetricsReporterService",
+    "report.interval.sec": 3,
+    "zookeeper.connect": "localhost:2181",
+    "bootstrap.servers": "localhost:9092",
+    "topic": "xinfra-monitor-topic-metrics",
+    "report.kafka.topic.replication.factor": 1,
+    "report.metrics.list": [
+      "kmf.services:type=produce-service,name=*:produce-availability-avg",
+      "kmf.services:type=consume-service,name=*:consume-availability-avg",
+      "kmf.services:type=produce-service,name=*:records-produced-total",
+      "kmf.services:type=consume-service,name=*:records-consumed-total",
+      "kmf.services:type=consume-service,name=*:records-lost-total",
+      "kmf.services:type=consume-service,name=*:records-duplicated-total",
+      "kmf.services:type=consume-service,name=*:records-delay-ms-avg",
+      "kmf.services:type=produce-service,name=*:records-produced-rate",
+      "kmf.services:type=produce-service,name=*:produce-error-rate",
+      "kmf.services:type=consume-service,name=*:consume-error-rate"
+    ]
+  }
 
 #  Example signalfx-service to report metrics
 # "signalfx-service": {


### PR DESCRIPTION

Addition of cluster-topic-manipulation-service and reporter-kafka-service in the xinfra monitor config
Signed-off-by: Andrew Choi <li_andchoi@microsoft.com>