### PR TITLE
Avoid NaN in Commit Offset Failure Rate OffsetCommitServiceMetrics by…

### DIFF
--- a/src/main/java/com/linkedin/xinfra/monitor/services/metrics/OffsetCommitServiceMetrics.java
+++ b/src/main/java/com/linkedin/xinfra/monitor/services/metrics/OffsetCommitServiceMetrics.java
@@ -51,13 +51,13 @@ public class OffsetCommitServiceMetrics extends XinfraMonitorMetrics {
         new Total());
 
     _offsetCommitFailSensor = metrics.sensor(FAILURE_SENSOR_NAME);
+    /* NaN will persist as long as no record is submitted to the failure sensor.
+       we'll continue with NaN for now since we'd rather that the Sensor itself is a true and unaltered record of what values it recorded. */
     _offsetCommitFailSensor.add(new MetricName(FAILURE_RATE_METRIC, METRIC_GROUP_NAME,
         "The failure rate of group coordinator accepting consumer offset commit requests.", tags), new Avg());
     _offsetCommitFailSensor.add(new MetricName(FAILURE_METRIC_TOTAL, METRIC_GROUP_NAME,
             "The total count of group coordinator unsuccessfully receiving consumer offset commit requests.", tags),
         new Total());
-    LOGGER.trace("Initializing the offset-commit-service-failure value to 0 to avoid NaN being reported.");
-    _offsetCommitFailSensor.record(0);
 
     Measurable measurable = new Measurable() {
       @Override

--- a/src/main/java/com/linkedin/xinfra/monitor/services/metrics/OffsetCommitServiceMetrics.java
+++ b/src/main/java/com/linkedin/xinfra/monitor/services/metrics/OffsetCommitServiceMetrics.java
@@ -56,6 +56,8 @@ public class OffsetCommitServiceMetrics extends XinfraMonitorMetrics {
     _offsetCommitFailSensor.add(new MetricName(FAILURE_METRIC_TOTAL, METRIC_GROUP_NAME,
             "The total count of group coordinator unsuccessfully receiving consumer offset commit requests.", tags),
         new Total());
+    LOGGER.trace("Initializing the offset-commit-service-failure value to 0 to avoid NaN being reported.");
+    _offsetCommitFailSensor.record(0);
 
     Measurable measurable = new Measurable() {
       @Override


### PR DESCRIPTION
… initializing with a zero only when instantiating.

**Avoid having XM reporting NaN for its failure rate by initializing the value of the failure rate sensor with a zero value.**

```
[2020-07-02 15:06:54,609] INFO ==============================================================
kmf:type=kafka-monitor:offline-runnable-count=0.0
kmf.services:name=offset-commit-service,type=offset-commit-service:offset-commit-availability-avg=1.0
kmf.services:name=offset-commit-service,type=offset-commit-service:offset-commit-service-success-rate=1.0
kmf.services:name=offset-commit-service,type=offset-commit-service:offset-commit-service-success-total=4.0
kmf.services:name=offset-commit-service,type=offset-commit-service:offset-commit-service-failure-rate=0.0
kmf.services:name=offset-commit-service,type=offset-commit-service:offset-commit-service-failure-total=0.0
 (com.linkedin.xinfra.monitor.services.DefaultMetricsReporterService)
```

`Signed-off-by: Andrew Choi <li_andchoi@microsoft.com>`