### PR TITLE
path fix for docker/Dockerfile and bin/single-cluster-monitor.sh

### DIFF
--- a/bin/single-cluster-monitor.sh
+++ b/bin/single-cluster-monitor.sh
@@ -9,4 +9,4 @@
 
 base_dir=$(dirname $0)
 
-exec $base_dir/kmf-run-class.sh com/linkedin/kmf/apps/SingleClusterMonitor $@
+exec $base_dir/kmf-run-class.sh com/linkedin/xinfra/monitor/apps/SingleClusterMonitor $@

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,7 +17,7 @@ MAINTAINER coffeepac@gmail.com
 
 WORKDIR /opt/kafka-monitor
 ADD build/ build/
-ADD bin/kafka-monitor-start.sh bin/kafka-monitor-start.sh
+ADD bin/xinfra-monitor-start.sh bin/xinfra-monitor-start.sh
 ADD bin/kmf-run-class.sh bin/kmf-run-class.sh
 ADD config/xinfra-monitor.properties config/xinfra-monitor.properties
 ADD config/log4j2.properties config/log4j2.properties


### PR DESCRIPTION
After cloning the project, I found that `docker/Dockerfile` is not able to build due to the path error of kafka-monitor-start.sh. Also com/linkedin/kmf/apps/SingleClusterMonitor path was wrong in `bin/single-cluster-monitor.sh` file. 