### PR TITLE
Issue #297: Fixed path in windows/kafka-monitor-start

### DIFF
--- a/bin/windows/kafka-monitor-start.bat
+++ b/bin/windows/kafka-monitor-start.bat
@@ -19,7 +19,7 @@ IF [%1] EQU [] (
 	EXIT /B 1
 )
 
-set COMMAND=%BASE_DIR%\kmf-run-class.bat com.linkedin.kmf.XinfraMonitor %*
+set COMMAND=%BASE_DIR%\kmf-run-class.bat com.linkedin.xinfra.monitor.XinfraMonitor %*
 
 rem echo basedir: %BASE_DIR%
 


### PR DESCRIPTION
Renamed main class path in bin/windows/kafka-monitor-start which is now sync with other files.