### PR TITLE
Addition of BlackListed Brokers to support KPC in cluster-topic-manipulation-service

### DIFF
--- a/config/xinfra-monitor.properties
+++ b/config/xinfra-monitor.properties
@@ -121,6 +121,7 @@
 
   "cluster-topic-manipulation-service":{
      "class.name":"com.linkedin.xinfra.monitor.services.ClusterTopicManipulationService",
+     "zookeeper.connect": "localhost:2181",
      "bootstrap.servers":"localhost:9092,localhost:9093"
   },
 

--- a/src/main/java/com/linkedin/xinfra/monitor/services/ClusterTopicManipulationServiceFactory.java
+++ b/src/main/java/com/linkedin/xinfra/monitor/services/ClusterTopicManipulationServiceFactory.java
@@ -45,6 +45,6 @@ public class ClusterTopicManipulationServiceFactory implements ServiceFactory {
 
     AdminClient adminClient = AdminClient.create(_properties);
 
-    return new ClusterTopicManipulationService(_serviceName, adminClient);
+    return new ClusterTopicManipulationService(_serviceName, adminClient, _properties);
   }
 }


### PR DESCRIPTION
Closes #306 
Addition of BlackListed Brokers to support KPC in cluster-topic-manipulation-service

This is a known issue on the open source Kafka Monitor. 
https://github.com/linkedin/kafka-monitor/issues/306 

1 - Related to KPC brokers (kafka preferred controller nodes), where topics for this class were created with replicas set on the preferred controller nodes as well.
2- Causing CruiseControl's UnfixableGoalViolation. Causes replicas to exist in preferred controller brokers. 
3 - topic: xinfra-monitor-cluster-topic-manipulation-service-topic with a different suffix each time.


Signed-off-by: Andrew Choi <li_andchoi@microsoft.com>