### PR TITLE
 Kafka 2.4 + KIP-455 for Xinfra Monitor Multie Cluster Topic Management Service 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ allprojects {
     compile 'net.savantly:graphite-client:1.1.0-RELEASE'
     compile 'com.timgroup:java-statsd-client:3.0.1'
     compile 'com.signalfx.public:signalfx-codahale:0.0.47'
-    compile group: 'org.apache.kafka', name: 'kafka_2.12', version: '2.3.1'
+    compile group: 'org.apache.kafka', name: 'kafka_2.12', version: '2.4.0'
     compile group: 'org.apache.kafka', name: 'kafka-clients', version: '2.3.1'
     testCompile 'org.mockito:mockito-core:2.24.0'
     testCompile 'org.testng:testng:6.8.8'

--- a/src/main/java/com/linkedin/xinfra/monitor/services/ConsumeService.java
+++ b/src/main/java/com/linkedin/xinfra/monitor/services/ConsumeService.java
@@ -11,12 +11,12 @@
 package com.linkedin.xinfra.monitor.services;
 
 import com.linkedin.xinfra.monitor.common.DefaultTopicSchema;
-import com.linkedin.xinfra.monitor.services.metrics.CommitAvailabilityMetrics;
-import com.linkedin.xinfra.monitor.services.metrics.CommitLatencyMetrics;
-import com.linkedin.xinfra.monitor.services.metrics.ConsumeMetrics;
 import com.linkedin.xinfra.monitor.common.Utils;
 import com.linkedin.xinfra.monitor.consumer.BaseConsumerRecord;
 import com.linkedin.xinfra.monitor.consumer.KMBaseConsumer;
+import com.linkedin.xinfra.monitor.services.metrics.CommitAvailabilityMetrics;
+import com.linkedin.xinfra.monitor.services.metrics.CommitLatencyMetrics;
+import com.linkedin.xinfra.monitor.services.metrics.ConsumeMetrics;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -40,7 +40,7 @@ import org.apache.kafka.common.metrics.MetricConfig;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.MetricsReporter;
 import org.apache.kafka.common.metrics.Sensor;
-import org.apache.kafka.common.metrics.stats.Total;
+import org.apache.kafka.common.metrics.stats.CumulativeSum;
 import org.apache.kafka.common.utils.SystemTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -244,7 +244,8 @@ public class ConsumeService implements Service {
       @SuppressWarnings("ConstantConditions")
       double partitionCount = topicDescription.partitions().size();
       topicPartitionCount.add(
-          new MetricName("topic-partitions-count", METRIC_GROUP_NAME, "The total number of partitions for the topic.", tags), new Total(partitionCount));
+          new MetricName("topic-partitions-count", METRIC_GROUP_NAME, "The total number of partitions for the topic.",
+              tags), new CumulativeSum(partitionCount));
     }
   }
 


### PR DESCRIPTION
`Kafka 2.4` + KIP-455 for Xinfra Monitor `Multi Cluster Topic Management Service` 

Total extends CumulativeSum : A non-sampled cumulative total maintained over all time.
 This is a non-sampled version of {@link WindowedSum}.
Total is deprecated since 2.4. Recommended to use {@link CumulativeSum} instead.

(New) CumulativeSum: A non-sampled cumulative total maintained over all time.
This is a non-sampled version of {@link WindowedSum}.