### PR TITLE
Add two config properties to disable the add-topic-partition procedure and the topic-reassig-partition-and-leader-elect procedure respectively

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,6 @@ src/test/java/com/linkedin/xinfra/monitor/RandomTests.java
 config/andrew-choi.properties
 config/andrew-multi-cluster-monitor.properties
 
-
+kafka-monitor.iml
+kafka-monitor.ipr
+kafka-monitor.iws

--- a/src/main/java/com/linkedin/xinfra/monitor/apps/SingleClusterMonitor.java
+++ b/src/main/java/com/linkedin/xinfra/monitor/apps/SingleClusterMonitor.java
@@ -277,6 +277,22 @@ public class SingleClusterMonitor implements App {
       .dest("autoTopicCreationEnabled")
       .help(TopicManagementServiceConfig.TOPIC_CREATION_ENABLED_DOC);
 
+    parser.addArgument("--topic-add-partition-enabled")
+      .action(net.sourceforge.argparse4j.impl.Arguments.store())
+      .required(false)
+      .type(Boolean.class)
+      .metavar("TOPIC_ADD_PARTITION_ENABLED")
+      .dest("topicAddPartitionEnabled")
+      .help(TopicManagementServiceConfig.TOPIC_ADD_PARTITION_ENABLED_DOC);
+
+    parser.addArgument("--topic-reassign-partition-and-elect-leader-enabled")
+      .action(net.sourceforge.argparse4j.impl.Arguments.store())
+      .required(false)
+      .type(Boolean.class)
+      .metavar("TOPIC_REASSIGN_PARTITION_AND_ELECT_LEADER_ENABLED")
+      .dest("topicReassignPartitionAndElectLeaderEnabled")
+      .help(TopicManagementServiceConfig.TOPIC_REASSIGN_PARTITION_AND_ELECT_LEADER_ENABLED_DOC);
+
     parser.addArgument("--replication-factor")
         .action(net.sourceforge.argparse4j.impl.Arguments.store())
         .required(false)
@@ -336,6 +352,10 @@ public class SingleClusterMonitor implements App {
     // topic management service config
     if (res.getBoolean("autoTopicCreationEnabled") != null)
       props.put(TopicManagementServiceConfig.TOPIC_CREATION_ENABLED_CONFIG, res.getBoolean("autoTopicCreationEnabled"));
+    if (res.getBoolean("topicAddPartitionEnabled") != null)
+      props.put(TopicManagementServiceConfig.TOPIC_ADD_PARTITION_ENABLED_CONFIG, res.getBoolean("topicAddPartitionEnabled"));
+    if (res.getBoolean("topicReassignPartitionAndElectLeaderEnabled") != null)
+      props.put(TopicManagementServiceConfig.TOPIC_REASSIGN_PARTITION_AND_ELECT_LEADER_ENABLED_CONFIG, res.getBoolean("topicReassignPartitionAndElectLeaderEnabled"));
     if (res.getInt("replicationFactor") != null)
       props.put(TopicManagementServiceConfig.TOPIC_REPLICATION_FACTOR_CONFIG, res.getInt("replicationFactor"));
     if (res.getInt("rebalanceMs") != null)

--- a/src/main/java/com/linkedin/xinfra/monitor/services/configs/TopicManagementServiceConfig.java
+++ b/src/main/java/com/linkedin/xinfra/monitor/services/configs/TopicManagementServiceConfig.java
@@ -50,6 +50,15 @@ public class TopicManagementServiceConfig extends AbstractConfig {
       + " in the config with replication factor %s and min ISR as max(%s - 1, 1). The partition number is determined based on %s and %s",
       TOPIC_REPLICATION_FACTOR_CONFIG, TOPIC_REPLICATION_FACTOR_CONFIG, PARTITIONS_TO_BROKERS_RATIO_CONFIG, MIN_PARTITION_NUM_DOC);
 
+  public static final String TOPIC_ADD_PARTITION_ENABLED_CONFIG = "topic-management.topicAddPartitionEnabled";
+  public static final String TOPIC_ADD_PARTITION_ENABLED_DOC = String.format("When true this service automatically add topic partition(s) "
+      + "if the current topic partition count is smaller than the partition number which is determined based on %s and %s",
+          PARTITIONS_TO_BROKERS_RATIO_CONFIG, MIN_PARTITION_NUM_DOC);
+
+  public static final String TOPIC_REASSIGN_PARTITION_AND_ELECT_LEADER_ENABLED_CONFIG = "topic-management.topicReassignPartitionAndElectLeaderEnabled";
+  public static final String TOPIC_REASSIGN_PARTITION_AND_ELECT_LEADER_ENABLED_DOC = "When true this service automatically balance topic partitions in"
+      + " a cluster to ensure a minimum number of leader replicas on each alive broker.";
+
   public static final String TOPIC_FACTORY_CLASS_CONFIG = "topic-management.topicFactory.class.name";
   public static final String TOPIC_FACTORY_CLASS_DOC = "The name of the class used to create topics.  This class must implement "
       + TopicFactory.class.getName() + ".";
@@ -93,6 +102,16 @@ public class TopicManagementServiceConfig extends AbstractConfig {
               true,
               ConfigDef.Importance.LOW,
               TOPIC_CREATION_ENABLED_DOC)
+      .define(TOPIC_ADD_PARTITION_ENABLED_CONFIG,
+              ConfigDef.Type.BOOLEAN,
+              true,
+              ConfigDef.Importance.LOW,
+              TOPIC_ADD_PARTITION_ENABLED_DOC)
+      .define(TOPIC_REASSIGN_PARTITION_AND_ELECT_LEADER_ENABLED_CONFIG,
+              ConfigDef.Type.BOOLEAN,
+              true,
+              ConfigDef.Importance.LOW,
+              TOPIC_REASSIGN_PARTITION_AND_ELECT_LEADER_ENABLED_DOC)
       .define(TOPIC_REPLICATION_FACTOR_CONFIG,
               ConfigDef.Type.INT,
               1,

--- a/src/test/java/com/linkedin/xinfra/monitor/services/MultiClusterTopicManagementServiceTest.java
+++ b/src/test/java/com/linkedin/xinfra/monitor/services/MultiClusterTopicManagementServiceTest.java
@@ -71,6 +71,8 @@ public class MultiClusterTopicManagementServiceTest {
     _topicManagementHelper._adminClient = Mockito.mock(AdminClient.class);
     _topicManagementHelper._topicFactory = Mockito.mock(TopicFactory.class);
     _topicManagementHelper._topicCreationEnabled = true;
+    _topicManagementHelper._topicAddPartitionEnabled = true;
+    _topicManagementHelper._topicReassignPartitionAndElectLeaderEnabled = true;
   }
 
   @AfterMethod


### PR DESCRIPTION
Config props added:

1. `topic-management.topicAddPartitionEnabled`
2. `topic-management.topicReassignPartitionAndElectLeaderEnabled`

Both default to `true` for backward compatibility.