### PR TITLE
Fix bad javadoc causing Travis deployment failure

### DIFF
--- a/src/main/java/com/linkedin/xinfra/monitor/services/metrics/CommitLatencyMetrics.java
+++ b/src/main/java/com/linkedin/xinfra/monitor/services/metrics/CommitLatencyMetrics.java
@@ -61,7 +61,6 @@ public class CommitLatencyMetrics {
 
   /**
    * start the recording of consumer offset commit
-   * @throws Exception if the offset commit is already in progress.
    */
   public void recordCommitStart() {
     if (!_inProgressCommit) {


### PR DESCRIPTION
Before distributing a new release to `Bintray`, `Travis` runs a gradle task to check for syntactic correctness of javadoc (i.e. `Task :javadoc`). As a result, any syntax error on JavaDoc prevents publishing a new version.

A recent patch (see https://github.com/linkedin/kafka-monitor/commit/343f6fa38a8a519b76003fee74b33e781627eced) introduced a JavaDoc error, which causes the following failure:

```
> Task :javadoc
/home/travis/build/linkedin/kafka-monitor/src/main/java/com/linkedin/xinfra/monitor/services/metrics/CommitLatencyMetrics.java:64: error: exception not thrown: java.lang.Exception
   * @throws Exception if the offset commit is already in progress.
             ^
/home/travis/build/linkedin/kafka-monitor/src/main/java/com/linkedin/xinfra/monitor/services/metrics/CommitLatencyMetrics.java:41: warning: no @param for latencyPercentileMaxMs
  public CommitLatencyMetrics(Metrics metrics, Map<String, String> tags, int latencyPercentileMaxMs,
         ^
/home/travis/build/linkedin/kafka-monitor/src/main/java/com/linkedin/xinfra/monitor/services/metrics/CommitLatencyMetrics.java:41: warning: no @param for latencyPercentileGranularityMs
  public CommitLatencyMetrics(Metrics metrics, Map<String, String> tags, int latencyPercentileMaxMs,
         ^
/home/travis/build/linkedin/kafka-monitor/src/main/java/com/linkedin/xinfra/monitor/common/ConsumerGroupCoordinatorUtils.java:50: warning: no @return
  public static String findCollision(String targetGroupId, AdminClient adminClient)
                       ^
/home/travis/build/linkedin/kafka-monitor/src/main/java/com/linkedin/xinfra/monitor/common/ConsumerGroupCoordinatorUtils.java:50: warning: no @throws for java.util.concurrent.ExecutionException
  public static String findCollision(String targetGroupId, AdminClient adminClient)
                       ^
/home/travis/build/linkedin/kafka-monitor/src/main/java/com/linkedin/xinfra/monitor/common/ConsumerGroupCoordinatorUtils.java:50: warning: no @throws for java.lang.InterruptedException
  public static String findCollision(String targetGroupId, AdminClient adminClient)
                       ^
/home/travis/build/linkedin/kafka-monitor/src/main/java/com/linkedin/xinfra/monitor/common/Utils.java:82: warning: no @throws for java.lang.InterruptedException
  public static Map<TopicPartition, PartitionReassignment> ongoingPartitionReassignments(AdminClient adminClient)
                                                           ^
/home/travis/build/linkedin/kafka-monitor/src/main/java/com/linkedin/xinfra/monitor/common/Utils.java:82: warning: no @throws for java.util.concurrent.ExecutionException
  public static Map<TopicPartition, PartitionReassignment> ongoingPartitionReassignments(AdminClient adminClient)
                                                           ^
/home/travis/build/linkedin/kafka-monitor/src/main/java/com/linkedin/xinfra/monitor/common/Utils.java:82: warning: no @throws for java.util.concurrent.TimeoutException
  public static Map<TopicPartition, PartitionReassignment> ongoingPartitionReassignments(AdminClient adminClient)
                                                           ^
/home/travis/build/linkedin/kafka-monitor/src/main/java/com/linkedin/xinfra/monitor/common/Utils.java:217: warning: no @param for producerId
  public static String jsonFromFields(String topic, long idx, long timestamp, String producerId, int msgSize) {
                       ^
/home/travis/build/linkedin/kafka-monitor/src/main/java/com/linkedin/xinfra/monitor/topicfactory/TopicFactory.java:38: warning: no @param for adminClient
  int createTopicIfNotExist(String topic, short replicationFactor, double partitionToBrokerRatio, Properties topicProperties, AdminClient adminClient)
      ^
/home/travis/build/linkedin/kafka-monitor/src/main/java/com/linkedin/xinfra/monitor/topicfactory/TopicFactory.java:38: warning: no @throws for java.util.concurrent.ExecutionException
  int createTopicIfNotExist(String topic, short replicationFactor, double partitionToBrokerRatio, Properties topicProperties, AdminClient adminClient)
      ^
/home/travis/build/linkedin/kafka-monitor/src/main/java/com/linkedin/xinfra/monitor/topicfactory/TopicFactory.java:38: warning: no @throws for java.lang.InterruptedException
  int createTopicIfNotExist(String topic, short replicationFactor, double partitionToBrokerRatio, Properties topicProperties, AdminClient adminClient)
      ^
/home/travis/build/linkedin/kafka-monitor/src/main/java/com/linkedin/xinfra/monitor/topicfactory/DefaultTopicFactory.java:25: warning: no @param for config
  public DefaultTopicFactory(Map<String, ?> config) {
         ^
/home/travis/build/linkedin/kafka-monitor/src/main/java/com/linkedin/xinfra/monitor/services/Service.java:50: warning: no @param for timeout
  void awaitShutdown(long timeout, TimeUnit unit);
       ^
/home/travis/build/linkedin/kafka-monitor/src/main/java/com/linkedin/xinfra/monitor/services/Service.java:50: warning: no @param for unit
  void awaitShutdown(long timeout, TimeUnit unit);
       ^
1 error
15 warnings
> Task :javadoc FAILED
FAILURE: Build failed with an exception.
* What went wrong:
Execution failed for task ':javadoc'.
> Javadoc generation failed. Generated Javadoc options file (useful for troubleshooting): '/home/travis/build/linkedin/kafka-monitor/build/tmp/javadoc/javadoc.options'
* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.
* Get more help at https://help.gradle.org
BUILD FAILED in 19s
8 actionable tasks: 8 executed
```

This patch fixes this failure to enable publishing new versions of this project:
```
$ ./gradlew javadoc
<-------------> 0% CONFIGURING [0s]

> Task :javadoc
<omitted for conciseness>
BUILD SUCCESSFUL in 6s
2 actionable tasks: 2 executed

```