### PR TITLE
Fix a bug so that the value of the config topic-management.preferredleader.election.check.interval.ms can be set to the MultiClusterTopicManagementService

### DIFF
--- a/src/main/java/com/linkedin/xinfra/monitor/apps/SingleClusterMonitor.java
+++ b/src/main/java/com/linkedin/xinfra/monitor/apps/SingleClusterMonitor.java
@@ -309,6 +309,14 @@ public class SingleClusterMonitor implements App {
       .dest("rebalanceMs")
       .help(MultiClusterTopicManagementServiceConfig.REBALANCE_INTERVAL_MS_DOC);
 
+    parser.addArgument("--topic-preferred-leader-election-interval-ms")
+      .action(net.sourceforge.argparse4j.impl.Arguments.store())
+      .required(false)
+      .type(Integer.class)
+      .metavar("PREFERED_LEADER_ELECTION_INTERVAL_MS")
+      .dest("preferredLeaderElectionIntervalMs")
+      .help(MultiClusterTopicManagementServiceConfig.PREFERRED_LEADER_ELECTION_CHECK_INTERVAL_MS_DOC);
+
     return parser;
   }
 
@@ -360,6 +368,8 @@ public class SingleClusterMonitor implements App {
       props.put(TopicManagementServiceConfig.TOPIC_REPLICATION_FACTOR_CONFIG, res.getInt("replicationFactor"));
     if (res.getInt("rebalanceMs") != null)
       props.put(MultiClusterTopicManagementServiceConfig.REBALANCE_INTERVAL_MS_CONFIG, res.getInt("rebalanceMs"));
+    if (res.getLong("preferredLeaderElectionIntervalMs") != null)
+      props.put(MultiClusterTopicManagementServiceConfig.PREFERRED_LEADER_ELECTION_CHECK_INTERVAL_MS_CONFIG, res.getLong("preferredLeaderElectionIntervalMs"));
     SingleClusterMonitor app = new SingleClusterMonitor(props, "single-cluster-monitor");
     app.start();
 

--- a/src/main/java/com/linkedin/xinfra/monitor/services/TopicManagementService.java
+++ b/src/main/java/com/linkedin/xinfra/monitor/services/TopicManagementService.java
@@ -58,8 +58,14 @@ public class TopicManagementService implements Service {
     Map<String, Object> serviceProps = new HashMap<>();
     serviceProps.put(MultiClusterTopicManagementServiceConfig.PROPS_PER_CLUSTER_CONFIG, configPerCluster);
     serviceProps.put(MultiClusterTopicManagementServiceConfig.TOPIC_CONFIG, props.get(TopicManagementServiceConfig.TOPIC_CONFIG));
-    if (props.containsKey(MultiClusterTopicManagementServiceConfig.REBALANCE_INTERVAL_MS_CONFIG))
-      serviceProps.put(MultiClusterTopicManagementServiceConfig.REBALANCE_INTERVAL_MS_CONFIG, props.get(MultiClusterTopicManagementServiceConfig.REBALANCE_INTERVAL_MS_CONFIG));
+    Object providedRebalanceIntervalMsConfig = props.get(MultiClusterTopicManagementServiceConfig.REBALANCE_INTERVAL_MS_CONFIG);
+    if (providedRebalanceIntervalMsConfig != null) {
+      serviceProps.put(MultiClusterTopicManagementServiceConfig.REBALANCE_INTERVAL_MS_CONFIG, providedRebalanceIntervalMsConfig);
+    }
+    Object providedPreferredLeaderElectionIntervalMsConfig = props.get(MultiClusterTopicManagementServiceConfig.PREFERRED_LEADER_ELECTION_CHECK_INTERVAL_MS_CONFIG);
+    if (providedPreferredLeaderElectionIntervalMsConfig != null) {
+      serviceProps.put(MultiClusterTopicManagementServiceConfig.PREFERRED_LEADER_ELECTION_CHECK_INTERVAL_MS_CONFIG, providedPreferredLeaderElectionIntervalMsConfig);
+    }
     return serviceProps;
   }
 


### PR DESCRIPTION
In the `createMultiClusterTopicManagementServiceProps`, we need to move the value (if it exists) of the `PREFERRED_LEADER_ELECTION_CHECK_INTERVAL_MS_CONFIG` config to the `serviceProps`. Otherwise, the value does not take effect in the `MultiClusterTopicManagementService` class.