### PR TITLE
Bump dependencies to fix security vulnerabilities

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,8 +31,13 @@ allprojects {
 
   dependencies {
     compile 'net.sourceforge.argparse4j:argparse4j:0.5.0'
-    compile 'org.apache.logging.log4j:log4j-slf4j-impl:2.13.0'
+    compile 'org.apache.logging.log4j:log4j-slf4j-impl:2.13.2'
     compile 'org.apache.avro:avro:1.4.1'
+    compile ('com.fasterxml.jackson.core:jackson-databind') {
+      version {
+          strictly '2.10.5.1'
+      }
+    }
     compile 'org.json:json:20140107'
     compile 'org.jolokia:jolokia-jvm:1.6.2'
     compile 'net.savantly:graphite-client:1.1.0-RELEASE'


### PR DESCRIPTION
Based on Snyk we have 3 vulneravilities that can be fixed. 2 dependencies can be bumped easily without issue. Kafka upgrade may be harder though. This PR bumps these two log4j and jackson databind.
![image](https://user-images.githubusercontent.com/27116427/112085982-8e854a80-8bdf-11eb-8ec1-a5e6542cbb7c.png)
