### PR TITLE
Update statsd sample for Xinfra Monitor

### DIFF
--- a/config/xinfra-monitor.properties
+++ b/config/xinfra-monitor.properties
@@ -151,13 +151,12 @@
 
 #  Example statsd-service to report metrics
 #  "statsd-service": {
-#      "class.name": "com.linkedin.kmf.services.StatsdMetricsReporterService",
+#      "class.name": "com.linkedin.xinfra.monitor.services.StatsdMetricsReporterService",
 #      "report.statsd.host": "localhost",
 #      "report.statsd.port": "8125",
-#      "report.statsd.prefix": "kafka-monitor",
+#      "report.statsd.prefix": "xinfra-monitor",
 #      "report.interval.sec": 1,
 #      "report.metrics.list": [
-#      "kmf:type=kafka-monitor:offline-runnable-count",
 #      "kmf.services:type=produce-service,name=*:produce-availability-avg",
 #      "kmf.services:type=consume-service,name=*:consume-availability-avg"
 #     ]


### PR DESCRIPTION
Update xinfra-monitor.properties with working example for statsd, as previous class.name is now deprecated/invalid.