### PR TITLE
StatsD reporting double support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ allprojects {
     compile 'org.json:json:20140107'
     compile 'org.jolokia:jolokia-jvm:1.6.2'
     compile 'net.savantly:graphite-client:1.1.0-RELEASE'
-    compile 'com.timgroup:java-statsd-client:3.0.1'
+    compile 'com.timgroup:java-statsd-client:3.0.2'
     compile 'com.signalfx.public:signalfx-codahale:0.0.47'
     compile group: 'org.apache.kafka', name: 'kafka_2.12', version: '2.4.0'
     compile group: 'org.apache.kafka', name: 'kafka-clients', version: '2.3.1'

--- a/src/main/java/com/linkedin/xinfra/monitor/services/StatsdMetricsReporterService.java
+++ b/src/main/java/com/linkedin/xinfra/monitor/services/StatsdMetricsReporterService.java
@@ -97,7 +97,7 @@ public class StatsdMetricsReporterService implements Service {
 
       for (MbeanAttributeValue attributeValue: attributeValues) {
         final String statsdMetricName = generateStatsdMetricName(attributeValue.mbean(), attributeValue.attribute());
-        _statsdClient.recordGaugeValue(statsdMetricName, new Double(attributeValue.value()).longValue());
+        _statsdClient.recordGaugeValue(statsdMetricName, attributeValue.value());
       }
     }
   }


### PR DESCRIPTION
Currently the StatsD reporting service converts metric values from double to long when calling the StatsD client.

This makes it unsuitable for the availability metrics because all digits after the decimal point are lost and therefore the only possible values are 1 (if value is 1) or 0 (if value is <1).

The next minor release of the StatsD client adds support for double value for gauges, without introducing any other changes:

https://github.com/tim-group/java-statsd-client/releases/tag/v3.0.2

This PR switches the StatsD client to this version and removes the conversion from double to long when calling the StatsD client, which fixes this issue and closes https://github.com/linkedin/kafka-monitor/issues/365

No tests were included for the StatsD service, however since the StatsD client ultimately converts the value supplied (wether long or double) to string to report to the StatsD server, this change should have no effect on any of the other metrics that are integers.