### PR TITLE
bump avro-util: 0.2.81 -> 0.2.118

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ allprojects {
     compile group: 'org.apache.kafka', name: 'kafka_2.12', version: '2.8.2'
     compile group: 'org.apache.kafka', name: 'kafka-clients', version: '2.8.2'
     compile 'org.apache.commons:commons-lang3:3.12.0'
-    compile 'com.linkedin.avroutil1:helper-all:0.2.81'
+    compile 'com.linkedin.avroutil1:helper-all:0.2.118'
     compile 'org.apache.zookeeper:zookeeper:3.8.0'
     testCompile 'org.mockito:mockito-core:2.24.0'
     testCompile 'org.testng:testng:6.8.8'


### PR DESCRIPTION
## Details

[CVE-2022-42889](https://github.com/advisories/GHSA-599f-7c49-w659) in avro-util:

> Arbitrary code execution in Apache Commons Text

closes https://github.com/linkedin/kafka-monitor/issues/379

## Testing Done

1. ./gradlew build
