### PR TITLE
Address github actions deprecations

### DIFF
--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -1,6 +1,10 @@
 name: Greetings
 
-on: [pull_request, issues]
+on:
+  pull_request:
+    types: ['opened']
+  issues:
+    types: ['opened']
 
 jobs:
   greeting:

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -11,21 +11,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         # bring in all history because the gradle versions plugin needs to "walk back" to the closest ancestor tag
         # to figure out what version this is. optimizing this is left as a challenge to future committers
         fetch-depth: 0
     - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v3
       with:
         java-version: 1.8
+        distribution: microsoft
     - name: Build with Gradle
         # add --info or --debug below for more details when trying to understand issues
       run: ./gradlew clean build javadoc --stacktrace --warning-mode all --no-daemon
     - name: Branch tag
       id: branch_tag
-      run: echo ::set-output name=RELEASE_TAG::${GITHUB_REF#refs/tags/}
+      run: echo "RELEASE_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
     - name: Publish to Jfrog
       env:
         JFROG_USER: ${{ secrets.JFROG_USER }}


### PR DESCRIPTION
from: https://github.com/linkedin/kafka-monitor/actions/runs/3299810452

> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout, actions/setup-java, actions/setup-java, actions/checkout

> The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

as well as run `greetings` workflow once
