### PR TITLE
Use long for Connection timeout parameters for NetworkClient 

### DIFF
--- a/src/main/java/com/linkedin/xinfra/monitor/services/OffsetCommitService.java
+++ b/src/main/java/com/linkedin/xinfra/monitor/services/OffsetCommitService.java
@@ -129,7 +129,7 @@ public class OffsetCommitService implements Service {
         config.getLong(ConsumerConfig.RECONNECT_BACKOFF_MAX_MS_CONFIG),
         config.getInt(ConsumerConfig.SEND_BUFFER_CONFIG), config.getInt(ConsumerConfig.RECEIVE_BUFFER_CONFIG),
         config.getInt(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG),
-        config.getInt(ConsumerConfig.SOCKET_CONNECTION_SETUP_TIMEOUT_MS_CONFIG), config.getInt(ConsumerConfig.SOCKET_CONNECTION_SETUP_TIMEOUT_MAX_MS_CONFIG),
+        config.getLong(ConsumerConfig.SOCKET_CONNECTION_SETUP_TIMEOUT_MS_CONFIG), config.getLong(ConsumerConfig.SOCKET_CONNECTION_SETUP_TIMEOUT_MAX_MS_CONFIG),
         ClientDnsLookup.DEFAULT, _time, true,
         new ApiVersions(), logContext);
 


### PR DESCRIPTION
NetworkClient constructor expects Long parameters for conn.timeout: 
https://github.com/apache/kafka/blob/2.8/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java#L142-L143