### PR TITLE
Fix arguments' types causing exception

### DIFF
--- a/src/main/java/com/linkedin/xinfra/monitor/services/OffsetCommitService.java
+++ b/src/main/java/com/linkedin/xinfra/monitor/services/OffsetCommitService.java
@@ -129,7 +129,7 @@ public class OffsetCommitService implements Service {
         config.getLong(ConsumerConfig.RECONNECT_BACKOFF_MAX_MS_CONFIG),
         config.getInt(ConsumerConfig.SEND_BUFFER_CONFIG), config.getInt(ConsumerConfig.RECEIVE_BUFFER_CONFIG),
         config.getInt(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG),
-        config.getInt(ConsumerConfig.SOCKET_CONNECTION_SETUP_TIMEOUT_MS_CONFIG), config.getInt(ConsumerConfig.SOCKET_CONNECTION_SETUP_TIMEOUT_MAX_MS_CONFIG),
+        config.getLong(ConsumerConfig.SOCKET_CONNECTION_SETUP_TIMEOUT_MS_CONFIG), config.getLong(ConsumerConfig.SOCKET_CONNECTION_SETUP_TIMEOUT_MAX_MS_CONFIG),
         ClientDnsLookup.DEFAULT, _time, true,
         new ApiVersions(), logContext);
 


### PR DESCRIPTION
### Problem
- Exception
```
Exception in thread "main" java.lang.ClassCastException: class java.lang.Long cannot be cast to class java.lang.Integer (java.lang.Long and java.lang.Integer are in module java.base of loader 'bootstrap')
        at org.apache.kafka.common.config.AbstractConfig.getInt(AbstractConfig.java:173)
        at com.linkedin.xinfra.monitor.services.OffsetCommitService.<init>(OffsetCommitService.java:132)
        at com.linkedin.xinfra.monitor.services.OffsetCommitServiceFactory.createService(OffsetCommitServiceFactory.java:53)
        at com.linkedin.xinfra.monitor.XinfraMonitor.<init>(XinfraMonitor.java:82)
        at com.linkedin.xinfra.monitor.XinfraMonitor.main(XinfraMonitor.java:186)
```
- #378 PR introduced new [arguments for Network client `long connectionSetupTimeoutMs` and `long connectionSetupTimeoutMaxMs`](https://github.com/linkedin/kafka-monitor/pull/378/files#diff-2d490a032d59e6cc9ec2d94cc7fe4311f08a01d1cd67de185dd8e005fa582cd3R131)
- but mistakenly used `getInt` instead of expected `getLong`

## Solition
- use expected `getLong` method

## TODO
- increase test coverage to avoid future regressions
